### PR TITLE
Last.fm API errors handling

### DIFF
--- a/lib/lastfm/client.ex
+++ b/lib/lastfm/client.ex
@@ -26,15 +26,15 @@ defmodule Lastfm.Client do
 
   See Lastfm API [documentation](https://www.last.fm/api/show/user.getRecentTracks) for more details.
   """
-  @callback scrobbles(user, {page, limit, from, to}, t) :: map | {:error, term()}
+  @callback scrobbles(user, {page, limit, from, to}, t) :: {:ok, map} | {:error, term()}
 
   @doc """
   Returns the total playcount, registered time for a user.
   """
-  @callback info(user, t) :: {integer, integer} | {:error, term()}
+  @callback info(user, t) :: {:ok, {integer, integer}} | {:error, term()}
 
   @doc """
   Returns the playcount and the latest scrobble date of a user for a given time range.
   """
-  @callback playcount(user, {from, to}, t) :: {integer, integer} | {:error, term()}
+  @callback playcount(user, {from, to}, t) :: {:ok, {integer, integer}} | {:error, term()}
 end

--- a/lib/lastfm/extract.ex
+++ b/lib/lastfm/extract.ex
@@ -45,23 +45,29 @@ defmodule Lastfm.Extract do
 
   defp handle_response(%{"user" => _} = resp, _type) do
     {
-      resp["user"]["playcount"] |> format(),
-      resp["user"]["registered"]["unixtime"] |> format()
+      :ok,
+      {
+        resp["user"]["playcount"] |> format(),
+        resp["user"]["registered"]["unixtime"] |> format()
+      }
     }
   end
 
   defp handle_response(%{"recenttracks" => _} = resp, :playcount) do
     {
-      resp["recenttracks"]["@attr"]["total"] |> format(),
-      resp["recenttracks"]["track"]
-      |> List.wrap()
-      |> Enum.find(& &1["date"])
-      |> get_in(["date", "uts"])
-      |> format()
+      :ok,
+      {
+        resp["recenttracks"]["@attr"]["total"] |> format(),
+        resp["recenttracks"]["track"]
+        |> List.wrap()
+        |> Enum.find(& &1["date"])
+        |> get_in(["date", "uts"])
+        |> format()
+      }
     }
   end
 
-  defp handle_response(%{"recenttracks" => _} = resp, _type), do: resp
+  defp handle_response(%{"recenttracks" => _} = resp, _type), do: {:ok, resp}
   defp handle_response(%{"error" => _, "message" => message}, _type), do: {:error, message}
   defp handle_response({:error, reason}, _type), do: {:error, reason}
 

--- a/lib/lastfm/file_archive.ex
+++ b/lib/lastfm/file_archive.ex
@@ -86,4 +86,6 @@ defmodule Lastfm.FileArchive do
         @file_io.write(to, scrobbles |> Jason.encode!(), [:compressed])
     end
   end
+
+  def write(_archive, {:error, api_message}, _options), do: {:error, api_message}
 end

--- a/lib/lastfm_archive.ex
+++ b/lib/lastfm_archive.ex
@@ -122,7 +122,7 @@ defmodule LastfmArchive do
       Utils.display_progress(archive)
 
       for year <- Utils.year_range(archive.temporal) do
-        {from, to} = Utils.build_time_range(year)
+        {from, to} = Utils.build_time_range(year, archive)
         sync_archive(archive, {from, to, Cache.get({user, year})}, options)
         @cache.serialise(user, @cache, options)
       end
@@ -141,7 +141,7 @@ defmodule LastfmArchive do
     options = Map.merge(@default_opts, Enum.into(options, @default_opts))
     time_ranges = Utils.build_time_range({from, to})
 
-    for time_range <- time_ranges, within_range?(time_range, archive.temporal) do
+    for time_range <- time_ranges do
       with {playcount, previous_results} <- Map.get(cache, time_range, %{}),
            true <- previous_results |> Enum.all?(&(&1 == :ok)) do
         Utils.display_skip_message(time_range, playcount)
@@ -208,10 +208,6 @@ defmodule LastfmArchive do
         extent: total,
         date: last_scrobble_time |> DateTime.from_unix!() |> DateTime.to_date()
     }
-  end
-
-  defp within_range?({from, to}, {registered_time, last_scrobble_time}) do
-    from < last_scrobble_time and to > registered_time
   end
 
   @doc """

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -55,6 +55,13 @@ defmodule LastfmArchive.Utils do
     IO.puts("Skipping #{from_date}, previously synced: #{playcount} scrobble(s)")
   end
 
+  def display_api_error_message({from, _to}, reason) do
+    from_date = DateTime.from_unix!(from) |> DateTime.to_date()
+
+    IO.puts("\n")
+    IO.puts("Last.fm API error while syncing #{from_date}: #{reason}")
+  end
+
   @doc """
   Read and unzip a file from the archive of a Lastfm user.
 

--- a/test/lastfm/extract_test.exs
+++ b/test/lastfm/extract_test.exs
@@ -37,7 +37,7 @@ defmodule Lastfm.ExtractTest do
         Plug.Conn.resp(conn, 200, recent_tracks(user, count))
       end)
 
-      assert %{"recenttracks" => %{"@attr" => %{"user" => ^user, "total" => ^count}}} =
+      assert {:ok, %{"recenttracks" => %{"@attr" => %{"user" => ^user, "total" => ^count}}}} =
                Extract.scrobbles("a_lastfm_user", params, api)
     end
 
@@ -78,7 +78,7 @@ defmodule Lastfm.ExtractTest do
         Plug.Conn.resp(conn, 200, user_info("a_lastfm_user", 1234, 1_472_601_600))
       end)
 
-      Extract.info("a_lastfm_user", api)
+      assert {:ok, {1234, 1_472_601_600}} == Extract.info("a_lastfm_user", api)
     end
 
     test "returns error tuple on API error response", %{bypass: bypass, api: api} do
@@ -129,7 +129,7 @@ defmodule Lastfm.ExtractTest do
         Plug.Conn.resp(conn, 200, recent_tracks("a_lastfm_user", count, last_scobble_time))
       end)
 
-      assert {^count, ^last_scobble_time} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
+      assert {:ok, {^count, ^last_scobble_time}} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
     end
 
     test "returns 0 count and nil last scrobble time when playcount is 0", context do
@@ -137,7 +137,7 @@ defmodule Lastfm.ExtractTest do
         Plug.Conn.resp(conn, 200, recent_tracks_zero_count())
       end)
 
-      assert {0, nil} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
+      assert {:ok, {0, nil}} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
     end
 
     test "returns 0 count and nil last scrobble time when Lastfm returns `now_playing` track", context do
@@ -145,7 +145,7 @@ defmodule Lastfm.ExtractTest do
         Plug.Conn.resp(conn, 200, recent_tracks_zero_count_now_playing())
       end)
 
-      assert {0, nil} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
+      assert {:ok, {0, nil}} = Extract.playcount("a_lastfm_user", context.time_range, context.api)
     end
 
     test "returns error tuple on API error response", context do

--- a/test/lastfm/file_archive_test.exs
+++ b/test/lastfm/file_archive_test.exs
@@ -120,6 +120,13 @@ defmodule Lastfm.FileArchiveTest do
       assert :ok == FileArchive.write(test_file_archive(context.id), context.data, filepath: context.path)
     end
 
+    test "handles scrobble retrieval errors from Last.fm API" do
+      api_error_message = "Operation failed - Something went wrong"
+
+      assert {:error, ^api_error_message} =
+               FileArchive.write(test_file_archive("test_user"), {:error, api_error_message})
+    end
+
     test "does not write to non existing archive",
          context = %{id: id, data_json: data_json, metadata: metadata, full_path: full_path} do
       Lastfm.FileIOMock

--- a/test/lastfm_archive_test.exs
+++ b/test/lastfm_archive_test.exs
@@ -15,7 +15,19 @@ defmodule LastfmArchiveTest do
     stub_with(Lastfm.FileArchiveMock, Lastfm.FileArchiveStub)
     stub_with(LastfmArchive.CacheMock, LastfmArchive.CacheStub)
 
-    :ok
+    total_scrobbles = 400
+    registered_time = DateTime.from_iso8601("2021-04-01T18:50:07Z") |> elem(1) |> DateTime.to_unix()
+    last_scrobble_time = DateTime.from_iso8601("2021-04-03T18:50:07Z") |> elem(1) |> DateTime.to_unix()
+
+    test_archive = %{
+      Archive.new("a_lastfm_user")
+      | temporal: {registered_time, last_scrobble_time},
+        extent: total_scrobbles,
+        date: ~D[2021-04-03],
+        type: FileArchive
+    }
+
+    %{user: "a_lastfm_user", archive: test_archive}
   end
 
   test "sync scrobbles to a new file archive" do
@@ -24,26 +36,15 @@ defmodule LastfmArchiveTest do
     capture_io(fn -> LastfmArchive.sync(user) end)
   end
 
-  test "sync/2 scrobbles to a new file archive" do
-    user = "a_lastfm_user"
-
-    total_scrobbles = 400
+  test "sync/2 scrobbles to a new file archive", %{user: user, archive: archive} do
     daily_playcount = 13
-    registered_time = DateTime.from_iso8601("2021-04-01T18:50:07Z") |> elem(1) |> DateTime.to_unix()
-    last_scrobble_time = DateTime.from_iso8601("2021-04-03T18:50:07Z") |> elem(1) |> DateTime.to_unix()
-
-    test_archive = %{
-      Archive.new(user)
-      | temporal: {registered_time, last_scrobble_time},
-        extent: total_scrobbles,
-        date: ~D[2021-04-03],
-        type: FileArchive
-    }
+    {registered_time, last_scrobble_time} = archive.temporal
+    total_scrobbles = archive.extent
 
     Lastfm.FileArchiveMock
-    |> expect(:describe, fn ^user, _options -> {:ok, test_archive} end)
-    |> expect(:update_metadata, fn ^test_archive, _options -> {:ok, test_archive} end)
-    |> stub(:update_metadata, fn _updated_archive, _options -> {:ok, test_archive} end)
+    |> expect(:describe, fn ^user, _options -> {:ok, archive} end)
+    |> expect(:update_metadata, fn ^archive, _options -> {:ok, archive} end)
+    |> stub(:update_metadata, fn _updated_archive, _options -> {:ok, archive} end)
 
     Lastfm.ClientMock
     |> expect(:info, fn ^user, _api -> {:ok, {total_scrobbles, registered_time}} end)
@@ -51,5 +52,59 @@ defmodule LastfmArchiveTest do
     |> stub(:playcount, fn ^user, _time_range, _api -> {:ok, {daily_playcount, 0}} end)
 
     capture_io(fn -> LastfmArchive.sync(user) end)
+  end
+
+  test "sync/2 handles initial user info API call error", %{user: user} do
+    Lastfm.ClientMock
+    |> stub(:info, fn ^user, _api -> {:error, "Last.fm API: something went wrong"} end)
+    |> expect(:playcount, 0, fn ^user, _time_range, _api -> {:ok, {0, 0}} end)
+
+    assert {:error, "Last.fm API: something went wrong"} == LastfmArchive.sync(user)
+  end
+
+  test "sync/2 handles initial total playcount API call error", %{user: user} do
+    Lastfm.ClientMock
+    |> expect(:info, 1, fn ^user, _api -> {:ok, {0, 0}} end)
+    |> stub(:playcount, fn ^user, _time_range, _api -> {:error, "Last.fm API: something went wrong"} end)
+
+    assert {:error, "Last.fm API: something went wrong"} == LastfmArchive.sync(user)
+  end
+
+  test "sync/2 handles time-range playcount API call error", %{user: user, archive: archive} do
+    {registered_time, last_scrobble_time} = archive.temporal
+    total_scrobbles = archive.extent
+    api_error = "Operation failed - Most likely the backend service failed. Please try again."
+
+    Lastfm.FileArchiveMock |> stub(:update_metadata, fn _archive, _options -> {:ok, archive} end)
+
+    Lastfm.ClientMock
+    |> expect(:info, fn ^user, _api -> {:ok, {total_scrobbles, registered_time}} end)
+    |> expect(:playcount, fn ^user, _time_range, _api -> {:ok, {total_scrobbles, last_scrobble_time}} end)
+    |> stub(:playcount, fn ^user, _time_range, _api -> {:error, api_error} end)
+
+    sync_message = capture_io(fn -> LastfmArchive.sync(user) end)
+    assert sync_message =~ "Last.fm API error while syncing"
+    assert sync_message =~ api_error
+  end
+
+  test "sync/2 handles and caches scrobbles API call error", %{user: user, archive: archive} do
+    daily_playcount = 13
+    {registered_time, last_scrobble_time} = archive.temporal
+    total_scrobbles = archive.extent
+    api_error = "Operation failed - Most likely the backend service failed. Please try again."
+
+    Lastfm.FileArchiveMock |> stub(:update_metadata, fn _archive, _options -> {:ok, archive} end)
+
+    Lastfm.ClientMock
+    |> expect(:info, fn ^user, _api -> {:ok, {total_scrobbles, registered_time}} end)
+    |> expect(:playcount, fn ^user, _time_range, _api -> {:ok, {total_scrobbles, last_scrobble_time}} end)
+    |> stub(:playcount, fn ^user, _time_range, _api -> {:ok, {daily_playcount, 0}} end)
+    |> stub(:scrobbles, fn ^user, _page_params, _api -> {:error, api_error} end)
+
+    LastfmArchive.CacheMock
+    |> expect(:put, 3, fn {^user, 2021}, {_from, _to}, {^daily_playcount, [{:error, _data}]}, _cache -> :ok end)
+
+    sync_message = capture_io(fn -> LastfmArchive.sync(user) end)
+    assert sync_message =~ "x"
   end
 end

--- a/test/lastfm_archive_test.exs
+++ b/test/lastfm_archive_test.exs
@@ -46,9 +46,9 @@ defmodule LastfmArchiveTest do
     |> stub(:update_metadata, fn _updated_archive, _options -> {:ok, test_archive} end)
 
     Lastfm.ClientMock
-    |> expect(:info, fn ^user, _api -> {total_scrobbles, registered_time} end)
-    |> expect(:playcount, fn ^user, _time_range, _api -> {total_scrobbles, last_scrobble_time} end)
-    |> stub(:playcount, fn ^user, _time_range, _api -> {daily_playcount, 0} end)
+    |> expect(:info, fn ^user, _api -> {:ok, {total_scrobbles, registered_time}} end)
+    |> expect(:playcount, fn ^user, _time_range, _api -> {:ok, {total_scrobbles, last_scrobble_time}} end)
+    |> stub(:playcount, fn ^user, _time_range, _api -> {:ok, {daily_playcount, 0}} end)
 
     capture_io(fn -> LastfmArchive.sync(user) end)
   end

--- a/test/support/client_stub.ex
+++ b/test/support/client_stub.ex
@@ -4,7 +4,7 @@ defmodule Lastfm.ClientStub do
   @registered_time DateTime.from_iso8601("2021-04-01T18:50:07Z") |> elem(1) |> DateTime.to_unix()
   @latest_scrobble_time DateTime.from_iso8601("2021-04-03T18:50:07Z") |> elem(1) |> DateTime.to_unix()
 
-  def info(_user, _api), do: {400, @registered_time}
-  def playcount(_user, _time_range, _api), do: {13, @latest_scrobble_time}
-  def scrobbles(_user, _page_params, _api), do: %{}
+  def info(_user, _api), do: {:ok, {400, @registered_time}}
+  def playcount(_user, _time_range, _api), do: {:ok, {13, @latest_scrobble_time}}
+  def scrobbles(_user, _page_params, _api), do: {:ok, %{}}
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -21,7 +21,14 @@ defmodule LastfmArchive.UtilsTest do
   end
 
   test "build_time_range/1 provides year time range" do
-    assert {1_609_459_200, 1_640_995_199} == Utils.build_time_range(2021)
+    {:ok, registered_date, 0} = DateTime.from_iso8601("2018-01-13T11:06:25Z")
+    {:ok, last_scrobble_date, 0} = DateTime.from_iso8601("2021-05-04T12:55:25Z")
+
+    assert {1_577_836_800, 1_609_459_199} ==
+             Utils.build_time_range(2020, %Lastfm.Archive{
+               creator: "a_lastfm_user",
+               temporal: {DateTime.to_unix(registered_date), DateTime.to_unix(last_scrobble_date)}
+             })
   end
 
   test "year_range/1 from first and latest scrobble times" do


### PR DESCRIPTION
This PR: 
- updates `Client` behaviour so that runtime errors from Last.fm API is handled properly 
- caches and handles API errors so that the corresponding (missing) scrobbles can be re-synced later
- do not cache sync results of today's scrobbles as the sync is always partial (sync of latter days shall pick up the complete set of scrobbles on this day)