### PR TITLE
feat: after_archive transform into Apache Parquet files

### DIFF
--- a/lib/lastfm_archive.ex
+++ b/lib/lastfm_archive.ex
@@ -127,28 +127,30 @@ defmodule LastfmArchive do
   end
 
   @doc """
-  Transform downloaded file archive into various storage formats for a Lastfm user.
+  Transform downloaded file archive into TSV or Apache Parquet formats for a Lastfm user.
 
   ### Example
 
   ```
     LastfmArchive.transform("a_lastfm_user", format: :tsv)
 
-    # or which currently transform archive of the default user to TSV files
+    # transform archive of the default user into TSV files
     LastfmArchive.transform()
   ```
+
+  Current output transform  formats: `:tsv`, `:parquet`.
 
   The function only transforms downloaded archive data on local filesystem. It does not fetch data from Lastfm,
   which can be done via `sync/2`.
 
-  The TSV files are created on a yearly basis and stored in `gzip` compressed format.
-  They are stored in a `tsv` directory within either the default `./lastfm_data/`
+  The transformed files are created on a yearly basis and stored in `gzip` compressed format.
+  They are stored in a `tsv` or `parquet` directory within either the default `./lastfm_data/`
   or the directory specified in config/config.exs (`:lastfm_archive, :data_dir`).
   """
   @spec transform(binary, transform_options) :: any
   def transform(user \\ LastfmClient.default_user(), options \\ [format: :tsv])
 
-  def transform(user, [format: :tsv] = options) when is_binary(user) do
+  def transform(user, [format: format] = options) when is_binary(user) and format in [:tsv, :parquet] do
     user
     |> metadata(:derived_archive, options)
     |> update_metadata(:derived_archive, options)

--- a/lib/lastfm_archive.ex
+++ b/lib/lastfm_archive.ex
@@ -18,7 +18,6 @@ defmodule LastfmArchive do
   alias LastfmArchive.LastfmClient.LastfmApi
   alias LastfmArchive.Utils
 
-  @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
   @path_io Application.compile_env(:lastfm_archive, :path_io, Elixir.Path)
 
   @type metadata :: LastfmArchive.Archive.Metadata.t()

--- a/lib/lastfm_archive/archive/metadata.ex
+++ b/lib/lastfm_archive/archive/metadata.ex
@@ -7,6 +7,7 @@ defmodule LastfmArchive.Archive.Metadata do
   use TypedStruct
 
   @archive Application.compile_env(:lastfm_archive, :file_archive, LastFmArchive.FileArchive)
+  @format_mimetypes %{tsv: "text/tab-separated-values", parquet: "application/vnd.apache.parquet"}
 
   @typedoc "Metadata descriping a Lastfm archive based on
   [Dublin Core Metadata Initiative](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/)."
@@ -59,7 +60,7 @@ defmodule LastfmArchive.Archive.Metadata do
     %{
       metadata
       | description: "Lastfm archive of #{metadata.creator} in #{format} format",
-        format: "text/tab-separated-values",
+        format: @format_mimetypes[format],
         source: "local file archive",
         type: DerivedArchive
     }

--- a/lib/lastfm_archive/archive/transformers/file_archive_transformer.ex
+++ b/lib/lastfm_archive/archive/transformers/file_archive_transformer.ex
@@ -5,35 +5,41 @@ defmodule LastfmArchive.Archive.Transformers.FileArchiveTransformer do
 
   @behaviour LastfmArchive.Behaviour.Transformer
 
+  alias Explorer.DataFrame
   alias LastfmArchive.Archive.Metadata
   alias LastfmArchive.Behaviour.Archive
 
-  import LastfmArchive.Utils, only: [create_dir: 2, create_filepath: 2, month_range: 2, year_range: 1, write: 3]
+  import LastfmArchive.Utils, only: [create_dir: 2, create_filepath: 2, month_range: 2, year_range: 1, write: 2]
   require Logger
 
+  @data_frame_io Application.compile_env(:lastfm_archive, :data_frame_io, DataFrame)
+  @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
+
   @impl true
-  def apply(%{creator: user} = metadata, format: :tsv) do
-    :ok = create_dir(user, format: :tsv)
-    :ok = transform(metadata, year_range(metadata.temporal) |> Enum.to_list())
+  def apply(%{creator: user} = metadata, [format: format] = opts) do
+    :ok = create_dir(user, format: format)
+    :ok = transform(metadata, year_range(metadata.temporal) |> Enum.to_list(), opts)
 
     {:ok, %{metadata | modified: DateTime.utc_now()}}
   end
 
-  defp transform(_metadata, []), do: :ok
+  defp transform(_metadata, [], _opts), do: :ok
 
-  defp transform(metadata, [year | rest]) when is_integer(year) do
-    transform(metadata, month_range(year, metadata))
-    transform(metadata, rest)
+  defp transform(metadata, [year | rest], opts) when is_integer(year) do
+    transform(metadata, month_range(year, metadata), opts)
+    transform(metadata, rest, opts)
   end
 
-  defp transform(%Metadata{creator: user} = metadata, [%Date{year: year} | _] = months) do
-    case create_filepath(user, "tsv/#{year}.tsv.gz") do
+  defp transform(%Metadata{creator: user} = metadata, [%Date{year: year} | _] = months, opts) do
+    format = Keyword.get(opts, :format)
+
+    case create_filepath(user, "#{format}/#{year}.#{format}.gz") do
       {:ok, filepath} ->
-        Logger.info("\nCreating TSV file for #{year} scrobbles.")
-        :ok = create_dataframe(metadata, months) |> write(filepath, format: :tsv)
+        Logger.info("\nCreating #{format} file for #{year} scrobbles.")
+        :ok = create_dataframe(metadata, months) |> write_data_frame(filepath, format: format)
 
       {:error, :file_exists} ->
-        Logger.info("\nTSV file exists, skipping #{year} scrobbles.")
+        Logger.info("\n#{format} file exists, skipping #{year} scrobbles.")
     end
   end
 
@@ -42,6 +48,17 @@ defmodule LastfmArchive.Archive.Transformers.FileArchiveTransformer do
       {:ok, df} = Archive.impl().read(metadata, month: month)
       df
     end
-    |> Explorer.DataFrame.concat_rows()
+    |> DataFrame.concat_rows()
+  end
+
+  defp write_data_frame(df, filepath, format: :tsv) do
+    write_fun = fn df ->
+      df
+      |> DataFrame.collect()
+      |> @data_frame_io.dump_csv!(delimiter: "\t")
+      |> then(fn data -> @file_io.write(filepath, data, [:compressed]) end)
+    end
+
+    write(df, write_fun)
   end
 end

--- a/lib/lastfm_archive/behaviour/data_frame_io.ex
+++ b/lib/lastfm_archive/behaviour/data_frame_io.ex
@@ -4,4 +4,5 @@ defmodule LastfmArchive.Behaviour.DataFrameIo do
   """
 
   @callback dump_csv!(df :: Explorer.DataFrame.t(), opts :: Keyword.t()) :: String.t()
+  @callback dump_parquet!(df :: Explorer.DataFrame.t(), opts :: Keyword.t()) :: binary()
 end

--- a/test/lastfm_archive/archive/transformers/file_archive_transformer_test.exs
+++ b/test/lastfm_archive/archive/transformers/file_archive_transformer_test.exs
@@ -13,6 +13,8 @@ defmodule LastfmArchive.Archive.Transformers.FileArchiveTransformerTest do
   alias Explorer.DataFrame
   alias Explorer.DataFrameMock
 
+  @formats [:tsv, :parquet]
+
   setup :verify_on_exit!
 
   setup do
@@ -27,51 +29,76 @@ defmodule LastfmArchive.Archive.Transformers.FileArchiveTransformerTest do
         date: ~D[2023-04-03]
       )
 
-    %{dir: Path.join(user_dir(user), "tsv"), user: user, metadata: metadata}
+    %{user: user, metadata: metadata}
   end
 
   describe "apply/3" do
-    test "TSV trasnformation", %{dir: dir, user: user, metadata: metadata} do
-      filepath1 = Path.join([user_dir(user), "tsv", "2022.tsv.gz"])
-      filepath2 = Path.join([user_dir(user), "tsv", "2023.tsv.gz"])
+    for format <- @formats do
+      setup context do
+        {func_format, opts} = if unquote(format) == :tsv, do: {:csv, [delimiter: "\t"]}, else: {unquote(format), []}
 
-      # read archive 16 times per 16 months scrobbles, 105 scrobbles each month
-      FileArchiveMock
-      |> expect(:read, 16, fn ^metadata, _option -> {:ok, data_frame()} end)
+        %{
+          dir: Path.join(user_dir(context.user), "#{unquote(format)}"),
+          format: {unquote(format), func_format},
+          options: opts
+        }
+      end
 
-      FileIOMock
-      |> expect(:exists?, fn ^dir -> false end)
-      |> expect(:exists?, fn ^filepath1 -> false end)
-      |> expect(:exists?, fn ^filepath2 -> false end)
-      |> expect(:mkdir_p, fn ^dir -> :ok end)
-      |> expect(:write, fn ^filepath1, _data, [:compressed] -> :ok end)
-      |> expect(:write, fn ^filepath2, _data, [:compressed] -> :ok end)
+      test "#{format} trasnformation", %{
+        dir: dir,
+        user: user,
+        metadata: metadata,
+        format: {format, func_format},
+        options: opts
+      } do
+        filepath1 = Path.join([user_dir(user), "#{format}", "2022.#{format}.gz"])
+        filepath2 = Path.join([user_dir(user), "#{format}", "2023.#{format}.gz"])
 
-      DataFrameMock
-      |> expect(:dump_csv!, fn %DataFrame{} = df, [delimiter: "\t"] ->
-        # whole year of scrobbles
-        assert df |> DataFrame.shape() == {12 * 105, 11}
-        tsv_data()
-      end)
-      |> expect(:dump_csv!, fn %DataFrame{} = df, [delimiter: "\t"] ->
-        # 4 month of scrobbles
-        assert df |> DataFrame.shape() == {4 * 105, 11}
-        tsv_data()
-      end)
+        # read archive 16 times per 16 months scrobbles, 105 scrobbles each month
+        FileArchiveMock
+        |> expect(:read, 16, fn ^metadata, _option -> {:ok, data_frame()} end)
 
-      assert capture_log(fn -> assert {:ok, _} = FileArchiveTransformer.apply(metadata, format: :tsv) end) =~ "Creating"
-    end
+        FileIOMock
+        |> expect(:exists?, fn ^dir -> false end)
+        |> expect(:exists?, fn ^filepath1 -> false end)
+        |> expect(:exists?, fn ^filepath2 -> false end)
+        |> expect(:mkdir_p, fn ^dir -> :ok end)
+        |> expect(:write, fn ^filepath1, _data, [:compressed] -> :ok end)
+        |> expect(:write, fn ^filepath2, _data, [:compressed] -> :ok end)
 
-    test "does not overwrite existing TSV file", %{dir: dir, metadata: metadata} do
-      FileIOMock
-      |> expect(:exists?, fn ^dir -> true end)
-      |> stub(:exists?, fn _filepath -> true end)
-      |> expect(:write, 0, fn __filepath, _data, [:compressed] -> :ok end)
+        DataFrameMock
+        |> expect(:"dump_#{func_format}!", fn %DataFrame{} = df, ^opts ->
+          # whole year of scrobbles
+          assert df |> DataFrame.shape() == {12 * 105, 11}
+          tsv_data()
+        end)
+        |> expect(:"dump_#{func_format}!", fn %DataFrame{} = df, ^opts ->
+          # 4 month of scrobbles
+          assert df |> DataFrame.shape() == {4 * 105, 11}
+          tsv_data()
+        end)
 
-      DataFrameMock
-      |> expect(:dump_csv!, 0, fn _df, [delimiter: "\t"] -> :ok end)
+        assert capture_log(fn -> assert {:ok, _} = FileArchiveTransformer.apply(metadata, format: format) end) =~
+                 "Creating"
+      end
 
-      assert capture_log(fn -> assert {:ok, _} = FileArchiveTransformer.apply(metadata, format: :tsv) end) =~ "skipping"
+      test "does not overwrite existing #{format} file", %{
+        dir: dir,
+        metadata: metadata,
+        format: {format, func_format},
+        options: opts
+      } do
+        FileIOMock
+        |> expect(:exists?, fn ^dir -> true end)
+        |> stub(:exists?, fn _filepath -> true end)
+        |> expect(:write, 0, fn __filepath, _data, [:compressed] -> :ok end)
+
+        DataFrameMock
+        |> expect(:"dump_#{func_format}!", 0, fn _df, ^opts -> :ok end)
+
+        assert capture_log(fn -> assert {:ok, _} = FileArchiveTransformer.apply(metadata, format: format) end) =~
+                 "skipping"
+      end
     end
   end
 end

--- a/test/lastfm_archive/utils_test.exs
+++ b/test/lastfm_archive/utils_test.exs
@@ -135,7 +135,7 @@ defmodule LastfmArchive.UtilsTest do
       |> expect(:write, 0, fn ^full_path, ^data_json, [:compressed] -> true end)
 
       assert_raise RuntimeError, "please provide a valid :filepath option", fn ->
-        Utils.write(file_archive_metadata(user), context.data)
+        Utils.write(file_archive_metadata(user), context.data, [])
       end
     end
   end

--- a/test/lastfm_archive_test.exs
+++ b/test/lastfm_archive_test.exs
@@ -25,7 +25,8 @@ defmodule LastfmArchiveTest do
     %{
       user: user,
       file_archive_metadata: file_archive_metadata,
-      tsv_archive_metadata: new_derived_archive_metadata(file_archive_metadata, format: :tsv)
+      tsv_archive_metadata: new_derived_archive_metadata(file_archive_metadata, format: :tsv),
+      parquet_archive_metadata: new_derived_archive_metadata(file_archive_metadata, format: :parquet)
     }
   end
 
@@ -70,6 +71,15 @@ defmodule LastfmArchiveTest do
       |> expect(:after_archive, fn ^metadata, FileArchiveTransformer, [format: :tsv] -> {:ok, metadata} end)
 
       LastfmArchive.transform(user, format: :tsv)
+    end
+
+    test "scrobbles of a user into Apache Parquet files", %{user: user, parquet_archive_metadata: metadata} do
+      DerivedArchiveMock
+      |> expect(:describe, fn ^user, _options -> {:ok, metadata} end)
+      |> expect(:update_metadata, 2, fn metadata, _options -> {:ok, metadata} end)
+      |> expect(:after_archive, fn ^metadata, FileArchiveTransformer, [format: :parquet] -> {:ok, metadata} end)
+
+      LastfmArchive.transform(user, format: :parquet)
     end
 
     test "scrobbles of default user with default (TSV) format", %{tsv_archive_metadata: metadata} do


### PR DESCRIPTION
This PR refactors `FileArchiveTransformer` and enable the transformation of Lastfm data into Apache Parquet columnar data files via `Explorer.DataFrame` IO function. 

Parquet data could be used for OLAP, analytics and visualisation use cases.