### PR TITLE
feat: most-frequent, play-once OTD analytics 

### DIFF
--- a/lib/lastfm_archive/analytics/commons.ex
+++ b/lib/lastfm_archive/analytics/commons.ex
@@ -16,14 +16,14 @@ defmodule LastfmArchive.Analytics.Commons do
   Compute frequency for a columns subset, filter untitled albums.
   """
   @spec frequencies(data_frame(), group()) :: data_frame()
-  def frequencies(df, "album"), do: df |> DataFrame.filter(album != "") |> DataFrame.frequencies(["album"])
-
   def frequencies(df, group) do
+    group = group |> List.wrap()
+
     case "album" in group do
       true -> df |> DataFrame.filter(album != "")
       false -> df
     end
-    |> DataFrame.frequencies(group |> List.wrap())
+    |> DataFrame.frequencies(group)
   end
 
   @doc """
@@ -86,10 +86,14 @@ defmodule LastfmArchive.Analytics.Commons do
   @doc """
   Rank data frame by total plays count and return top n rows.
   """
-  @spec most_played(data_frame(), integer) :: data_frame()
-  def most_played(df, rows \\ 5) do
+  @spec most_played(data_frame(), list()) :: data_frame()
+  def most_played(df, opts \\ []) do
+    opts = Keyword.validate!(opts, default_opts())
+
     df
-    |> DataFrame.arrange(desc: total_plays)
-    |> DataFrame.head(rows)
+    |> DataFrame.arrange_with(&[desc: &1[opts[:sort_by]]])
+    |> DataFrame.head(opts[:rows])
   end
+
+  def default_opts, do: [rows: 5, sort_by: "total_plays"]
 end

--- a/lib/lastfm_archive/analytics/on_this_day.ex
+++ b/lib/lastfm_archive/analytics/on_this_day.ex
@@ -9,6 +9,8 @@ defmodule LastfmArchive.Analytics.OnThisDay do
   require Explorer.DataFrame
   alias Explorer.DataFrame
 
+  import Explorer.Series, only: [not_equal: 2]
+
   def columns, do: ["id", "artist", "datetime", "year", "album", "name"]
 
   @impl true
@@ -34,12 +36,14 @@ defmodule LastfmArchive.Analytics.OnThisDay do
   end
 
   def render_most_played(df) do
+    not_untitled_albums = &not_equal(&1["album"], "")
+
     [
       {
         "<< most plays >>",
         [
           top_artists(df, rows: 8) |> most_played_ui(),
-          top_albums(df, rows: 8) |> most_played_ui(),
+          top_albums(df, rows: 8, filter: not_untitled_albums) |> most_played_ui(),
           top_tracks(df, rows: 8) |> most_played_ui()
         ]
         |> Kino.Layout.grid(columns: 3)
@@ -48,7 +52,7 @@ defmodule LastfmArchive.Analytics.OnThisDay do
         "<< most frequent over the years >>",
         [
           top_artists(df, rows: 8, sort_by: "years_freq") |> most_played_ui(),
-          top_albums(df, rows: 8, sort_by: "years_freq") |> most_played_ui(),
+          top_albums(df, rows: 8, sort_by: "years_freq", filter: not_untitled_albums) |> most_played_ui(),
           top_tracks(df, rows: 8, sort_by: "years_freq") |> most_played_ui()
         ]
         |> Kino.Layout.grid(columns: 3)

--- a/lib/lastfm_archive/analytics/on_this_day.ex
+++ b/lib/lastfm_archive/analytics/on_this_day.ex
@@ -56,6 +56,15 @@ defmodule LastfmArchive.Analytics.OnThisDay do
           top_tracks(df, rows: 8, sort_by: "years_freq") |> most_played_ui()
         ]
         |> Kino.Layout.grid(columns: 3)
+      },
+      {
+        "<< play once samples >>",
+        [
+          sample_artists(df, rows: 8, counts: 1) |> most_played_ui(),
+          sample_albums(df, rows: 8, counts: 1, filter: not_untitled_albums) |> most_played_ui(),
+          sample_tracks(df, rows: 8, counts: 1) |> most_played_ui()
+        ]
+        |> Kino.Layout.grid(columns: 3)
       }
     ]
     |> Kino.Layout.tabs()

--- a/lib/lastfm_archive/analytics/on_this_day.ex
+++ b/lib/lastfm_archive/analytics/on_this_day.ex
@@ -31,15 +31,29 @@ defmodule LastfmArchive.Analytics.OnThisDay do
     df
     |> data_frame_stats()
     |> overview_ui()
-    |> Kino.render()
   end
 
   def render_most_played(df) do
     [
-      top_artists(df, rows: 8) |> most_played_ui(),
-      top_albums(df, rows: 8) |> most_played_ui(),
-      top_tracks(df, rows: 8) |> most_played_ui()
+      {
+        "<< most plays >>",
+        [
+          top_artists(df, rows: 8) |> most_played_ui(),
+          top_albums(df, rows: 8) |> most_played_ui(),
+          top_tracks(df, rows: 8) |> most_played_ui()
+        ]
+        |> Kino.Layout.grid(columns: 3)
+      },
+      {
+        "<< most frequent over the years >>",
+        [
+          top_artists(df, rows: 8, sort_by: "years_freq") |> most_played_ui(),
+          top_albums(df, rows: 8, sort_by: "years_freq") |> most_played_ui(),
+          top_tracks(df, rows: 8, sort_by: "years_freq") |> most_played_ui()
+        ]
+        |> Kino.Layout.grid(columns: 3)
+      }
     ]
-    |> Kino.Layout.grid(columns: 3)
+    |> Kino.Layout.tabs()
   end
 end

--- a/lib/lastfm_archive/analytics/settings.ex
+++ b/lib/lastfm_archive/analytics/settings.ex
@@ -20,4 +20,6 @@ defmodule LastfmArchive.Analytics.Settings do
   def facet_type(%{"album" => _}), do: :album
   def facet_type(%{"artist" => _}), do: :artist
   def facet_type(%{"name" => _}), do: :track
+
+  def default_opts(), do: [rows: 5, sort_by: "total_plays", filter: nil, counts: -1]
 end

--- a/lib/lastfm_archive/behaviour/analytics.ex
+++ b/lib/lastfm_archive/behaviour/analytics.ex
@@ -38,7 +38,7 @@ defmodule LastfmArchive.Behaviour.Analytics do
       @behaviour LastfmArchive.Behaviour.Analytics
 
       import LastfmArchive.Analytics.Commons,
-        only: [default_opts: 0, frequencies: 2, create_group_stats: 2, create_facet_stats: 2, most_played: 2]
+        only: [create_group_stats: 2, create_facet_stats: 2, default_opts: 0, frequencies: 3, most_played: 2]
 
       @impl true
       def data_frame_stats(df) do
@@ -66,7 +66,7 @@ defmodule LastfmArchive.Behaviour.Analytics do
           opts = Keyword.validate!(options, default_opts())
 
           df
-          |> frequencies(group)
+          |> frequencies(group, filter: opts[:filter])
           |> create_group_stats(facet)
           |> most_played(opts)
           |> create_facet_stats(df)

--- a/lib/lastfm_archive/behaviour/analytics.ex
+++ b/lib/lastfm_archive/behaviour/analytics.ex
@@ -38,7 +38,7 @@ defmodule LastfmArchive.Behaviour.Analytics do
       @behaviour LastfmArchive.Behaviour.Analytics
 
       import LastfmArchive.Analytics.Commons,
-        only: [frequencies: 2, create_group_stats: 2, create_facet_stats: 2, most_played: 2]
+        only: [default_opts: 0, frequencies: 2, create_group_stats: 2, create_facet_stats: 2, most_played: 2]
 
       @impl true
       def data_frame_stats(df) do
@@ -63,12 +63,12 @@ defmodule LastfmArchive.Behaviour.Analytics do
         def unquote(:"top_#{facet}s")(df, options \\ []) do
           facet = if unquote(facet) == :track, do: :name, else: unquote(facet)
           group = [facet, :year]
-          rows = Keyword.get(options, :rows, 5)
+          opts = Keyword.validate!(options, default_opts())
 
           df
           |> frequencies(group)
           |> create_group_stats(facet)
-          |> most_played(rows)
+          |> most_played(opts)
           |> create_facet_stats(df)
         end
 

--- a/lib/lastfm_archive/behaviour/livebook_analytics.ex
+++ b/lib/lastfm_archive/behaviour/livebook_analytics.ex
@@ -27,11 +27,12 @@ defmodule LastfmArchive.Behaviour.LivebookAnalytics do
         facet_type = "#{facet_type}"
 
         [
+          "#### ",
           "#### #{facet_type |> String.capitalize()}s",
           for {%{"total_plays" => count} = row, index} <- facets |> Explorer.DataFrame.to_rows() |> Enum.with_index() do
             type = if facet_type == "track", do: "name", else: facet_type
 
-            "- **#{row[type]}** <sup>#{count}x</sup> <br/>" <>
+            "#{index + 1}. **#{row[type]}** <sup>#{count}x</sup> <br/>" <>
               render(stats[index], facet_type) <> (row |> map_years() |> render_years())
           end
         ]

--- a/lib/lastfm_archive/behaviour/livebook_analytics.ex
+++ b/lib/lastfm_archive/behaviour/livebook_analytics.ex
@@ -82,7 +82,7 @@ defmodule LastfmArchive.Behaviour.LivebookAnalytics do
   end
 
   def render_years(years) do
-    for(year <- years, do: "<small>#{year}#{Date.utc_today() |> Calendar.strftime("-%m-%d")}</small>")
+    for(year <- years, do: "<small>#{year}</small>")
     |> Enum.join(", ")
   end
 

--- a/livebook/analytics/on_this_day.livemd
+++ b/livebook/analytics/on_this_day.livemd
@@ -44,7 +44,7 @@ Analytics of all music played on this day, today in this past. This Livebook is 
 
 ```elixir
 dataframe
-|> tap(fn df -> OnThisDay.render_overview(df) end)
+|> tap(fn df -> OnThisDay.render_overview(df) |> Kino.render() end)
 |> OnThisDay.render_most_played()
 ```
 

--- a/test/lastfm_archive/analytics/commons_test.exs
+++ b/test/lastfm_archive/analytics/commons_test.exs
@@ -21,15 +21,16 @@ defmodule LastfmArchive.Analytics.CommonsTest do
       assert df["counts"] |> Series.to_list() == [1]
     end
 
-    test "filters out untitled albums" do
+    test "filter option to exclude untitled albums" do
       df = recent_tracks_without_album_title() |> data_frame()
+      filter_fun = &Series.not_equal(&1["album"], "")
 
       group = ["album", "year"]
-      assert %Explorer.DataFrame{} = df = Commons.frequencies(df, group) |> DataFrame.collect()
+      assert %Explorer.DataFrame{} = df = Commons.frequencies(df, group, filter: filter_fun) |> DataFrame.collect()
       assert df["counts"] |> Series.to_list() == []
 
       group = "album"
-      assert %Explorer.DataFrame{} = df = Commons.frequencies(df, group) |> DataFrame.collect()
+      assert %Explorer.DataFrame{} = df = Commons.frequencies(df, group, filter: filter_fun) |> DataFrame.collect()
       assert df["counts"] |> Series.to_list() == []
     end
   end


### PR DESCRIPTION
This PR refactors and updates `Analytics`, `LivebookAnalytics` behaviour's template implementations to include two new "on-this-day" analytics via Livebook/Kino tabs:

1. **most frequent**: artists, albums and tracks that are regularly played over the years. These metrics are based on the frequency (per year) which is different from the accumulative "top X" count-based metrics. This shows up facets that are popular in longer- terms, _cf._ short-term binges. <br/><br/><img width="1075" alt="Screenshot 2023-08-14 at 16 07 10" src="https://github.com/boonious/lastfm_archive/assets/104361/f0aa3896-a5a7-4b9d-baae-84ee3eb28412"> <br/><br/>
2. **play once** (samples): samples of artists, albums are tracks that occurred once on this day over the years.  <br/><br/><img width="1070" alt="Screenshot 2023-08-14 at 16 07 46" src="https://github.com/boonious/lastfm_archive/assets/104361/9db6abb4-0636-4e7b-80a2-be9922ee43e2">
