### PR TITLE
feat: sync/2` options - year, date, overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## 1.1.0 (2023-09-06)
+
+* `year`, `date`, `overwrite` options for `LastfmArchive.sync/2`
+* refactor: `.cache` hidden directory hosting cache files
+* refactor: split `LastfmArchive.Cache` into behaviour, client, server modules
+* refactor: extract date time logic from `LastfmArchive.Utils` into a separate module
+
 ## 1.0.0 (2023-09-01)
 
 * faceted archive: deriving multiple facets (archives) from the same file archive in support of analytics use cases

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ chunked into 200-track (max) `gzip` compressed pages and stored within directori
 corresponding to the days when tracks were scrobbled. The file archive in a main 
 directory specified in configuration - see below.
 
+See [`sync/2`](https://hexdocs.pm/lastfm_archive/LastfmArchive.html#sync/2) for
+various archiving options such `overwrite`, `year`, `date`.
+
 ### Transform into columnar storage formats
 You can transform the file archive into other common storage formats such as CSV and 
 columnar data structure such as [Apache Parquet](https://parquet.apache.org). 
@@ -145,7 +148,7 @@ to your list of dependencies in `mix.exs`:
 ```elixir
   def deps do
     [
-      {:lastfm_archive, "~> 1.0"}
+      {:lastfm_archive, "~> 1.1"}
     ]
   end
 ```

--- a/lib/lastfm_archive.ex
+++ b/lib/lastfm_archive.ex
@@ -85,7 +85,11 @@ defmodule LastfmArchive do
   max number of tracks per request permissible by Lastfm
 
   - `:data_dir` - default `lastfm_data`. The file archive is created within a main data directory,
-  e.g. `./lastfm_data/a_lastfm_user/`.
+  e.g. `./lastfm_data/a_lastfm_user/`
+
+  - `:year` - archive scrobbles of this year only
+
+  - `:date` - archive scrobbles of this date only
 
   These options can be configured in `config/config.exs`:
 

--- a/lib/lastfm_archive/application.ex
+++ b/lib/lastfm_archive/application.ex
@@ -4,7 +4,7 @@ defmodule LastfmArchive.Application do
   use Application
 
   def start(_type, _args) do
-    children = [LastfmArchive.Cache]
+    children = [LastfmArchive.Cache.Server]
 
     opts = [strategy: :one_for_one, name: LastfmArchive.Supervisor]
     Supervisor.start_link(children, opts)

--- a/lib/lastfm_archive/archive/derived_archive.ex
+++ b/lib/lastfm_archive/archive/derived_archive.ex
@@ -11,6 +11,8 @@ defmodule LastfmArchive.Archive.DerivedArchive do
 
   use LastfmArchive.Behaviour.DataFrameIo, formats: TransformerSettings.formats()
 
+  import LastfmArchive.Utils.DateTime, only: [year_range: 1]
+
   @type read_options :: [year: integer(), columns: list(atom()), format: atom(), facet: atom()]
 
   @impl true

--- a/lib/lastfm_archive/archive/derived_archive.ex
+++ b/lib/lastfm_archive/archive/derived_archive.ex
@@ -58,12 +58,12 @@ defmodule LastfmArchive.Archive.DerivedArchive do
   defp fetch_years(%Metadata{} = metadata, nil), do: {:ok, year_range(metadata.temporal) |> Enum.to_list()}
   defp fetch_years(%Metadata{} = _metadata, year), do: {:ok, [year]}
 
-  defp filepath(dir, :csv, user, year), do: Path.join(user_dir(user), "#{dir}/#{year}.csv.gz")
-  defp filepath(dir, format, user, year), do: Path.join(user_dir(user), "#{dir}/#{year}.#{format}")
+  defp filepath(dir, :csv, user_dir, year), do: Path.join(user_dir, "#{dir}/#{year}.csv.gz")
+  defp filepath(dir, format, user_dir, year), do: Path.join(user_dir, "#{dir}/#{year}.#{format}")
 
   defp create_lazy_dataframe(years, user, facet, format, opts) do
     for year <- years do
-      filepath(derived_archive_dir(format: format, facet: facet), format, user, year)
+      filepath(derived_archive_dir(format: format, facet: facet), format, user_dir(user, opts), year)
       |> load_data_frame(format, opts)
       |> Explorer.DataFrame.to_lazy()
     end

--- a/lib/lastfm_archive/archive/file_archive.ex
+++ b/lib/lastfm_archive/archive/file_archive.ex
@@ -11,6 +11,7 @@ defmodule LastfmArchive.Archive.FileArchive do
   alias LastfmArchive.Behaviour.LastfmClient
 
   alias LastfmArchive.Cache
+  alias LastfmArchive.Cache.Server, as: CacheServer
   alias LastfmArchive.LastfmClient.LastfmApi
 
   import LastfmArchive.Utils
@@ -24,7 +25,6 @@ defmodule LastfmArchive.Archive.FileArchive do
 
   @impl true
   def archive(metadata, options, api \\ LastfmApi.new("user.getrecenttracks"))
-
   def archive(%{extent: 0} = metadata, _options, _api), do: {:ok, metadata}
 
   def archive(%{creator: user} = metadata, options, api) do
@@ -38,15 +38,15 @@ defmodule LastfmArchive.Archive.FileArchive do
     end
   end
 
-  defp setup(user, options) do
-    maybe_create_dir(user, dir: Cache.cache_dir())
+  defp setup(user, opts) do
+    maybe_create_dir(user_dir(user, opts), sub_dir: Cache.cache_dir())
 
     # migrate previous cache files to .cache dir
     # to be removed in a future version
-    maybe_migrate_old_cache_files(user, options)
+    maybe_migrate_old_cache_files(user, opts)
 
     # needs unloading when archiving session is done
-    @cache.load(user, @cache, options)
+    @cache.load(user, CacheServer, opts)
   end
 
   defp archive(%{creator: user} = metadata, options, api, years, date) when is_nil(date) do
@@ -54,8 +54,8 @@ defmodule LastfmArchive.Archive.FileArchive do
 
     for year <- years do
       {from, to} = time_for_year(year, metadata.temporal)
-      :ok = write_to_archive(metadata, {from, to, @cache.get({user, year}, @cache)}, api, options)
-      @cache.serialise(user, @cache, options)
+      :ok = write_to_archive(metadata, {from, to, @cache.get({user, year}, CacheServer)}, api, options)
+      @cache.serialise(user, CacheServer, options)
     end
   end
 
@@ -66,8 +66,8 @@ defmodule LastfmArchive.Archive.FileArchive do
 
     case date_in_range?(metadata, {from, to}) do
       true ->
-        :ok = write_to_archive(metadata, {from, to, @cache.get({user, year}, @cache)}, api, options)
-        @cache.serialise(user, @cache, options)
+        :ok = write_to_archive(metadata, {from, to, @cache.get({user, year}, CacheServer)}, api, options)
+        @cache.serialise(user, CacheServer, options)
 
       false ->
         raise("date option out of range")
@@ -86,15 +86,16 @@ defmodule LastfmArchive.Archive.FileArchive do
     {years, Keyword.fetch!(options, :date)}
   end
 
-  defp maybe_migrate_old_cache_files(user, options) do
-    Path.join(user_dir(user, options), ".cache_????")
+  defp maybe_migrate_old_cache_files(user, opts) do
+    Path.join(user_dir(user, opts), ".cache_????")
     |> Path.wildcard(match_dot: true)
-    |> Enum.each(&rename_file(user, options, &1))
+    |> Enum.each(&rename_file(user, opts, &1))
   end
 
-  defp rename_file(user, options, old_cache_file) do
+  defp rename_file(user, opts, old_cache_file) do
     ".cache_" <> year = old_cache_file |> Path.basename()
-    new_file = Path.join([user_dir(user, options), Cache.cache_dir(), year])
+
+    new_file = Path.join([user_dir(user, opts), Cache.cache_dir(), year])
     Logger.info("migrate old cache file #{old_cache_file} to #{new_file}")
 
     File.rename(old_cache_file, new_file)
@@ -106,9 +107,9 @@ defmodule LastfmArchive.Archive.FileArchive do
   def read(%{creator: user} = _metadata, month: %Date{} = date), do: {:ok, do_read(user, month: date)}
   def read(_metadata, _options), do: {:error, :einval}
 
-  defp do_read(user, option) do
-    for filepath <- ls_archive_files(user, option) do
-      create_lazy_data_frame(user, filepath)
+  defp do_read(user, opts) do
+    for filepath <- ls_archive_files(user, opts) do
+      create_lazy_data_frame(Path.join(user_dir(user, opts), filepath))
     end
     |> case do
       [] -> {:error, :einval}
@@ -116,8 +117,8 @@ defmodule LastfmArchive.Archive.FileArchive do
     end
   end
 
-  defp create_lazy_data_frame(user, filepath) do
-    LastfmArchive.Utils.read(user, filepath)
+  defp create_lazy_data_frame(filepath) do
+    LastfmArchive.Utils.read(filepath)
     |> then(fn {:ok, scrobbles} -> scrobbles |> Jason.decode!() end)
     |> Scrobble.new()
     |> Enum.map(&Map.from_struct/1)
@@ -133,14 +134,16 @@ defmodule LastfmArchive.Archive.FileArchive do
       reset: Application.get_env(:lastfm_archive, :reset, false),
       data_dir: Application.get_env(:lastfm_archive, :data_dir, "./lastfm_data/"),
       date: nil,
-      year: nil
+      year: nil,
+      overwrite: false
     ]
   end
 
   defp write_to_archive(metadata, {from, to, cache}, api, options) do
     for day_range <- daily_time_ranges({from, to}) do
       with {playcount, previous_results} <- Map.get(cache, day_range, {}),
-           true <- previous_results |> Enum.all?(&(&1 == :ok)) do
+           true <- previous_results |> Enum.all?(&(&1 == :ok)),
+           false <- Keyword.fetch!(options, :overwrite) do
         Logger.info("Skipping #{date(day_range)}, previously synced: #{playcount} scrobble(s)")
       else
         # new daily archiving or redo previous erroneous archiving
@@ -161,8 +164,8 @@ defmodule LastfmArchive.Archive.FileArchive do
       results = write_to_archive(metadata, time_range, num_pages, api, options)
 
       # don't cache results of the always partial sync of today's scrobbles
-      unless today?(time_range) do
-        @cache.put({metadata.identifier, year}, time_range, {playcount, results}, options, @cache)
+      unless today?(from) do
+        @cache.put({metadata.identifier, year}, time_range, {playcount, results}, options, CacheServer)
       end
     else
       {:error, reason} ->
@@ -172,14 +175,14 @@ defmodule LastfmArchive.Archive.FileArchive do
 
   defp write_to_archive(_metadata, _time_range, 0, _api, _options), do: [:ok]
 
-  defp write_to_archive(%{identifier: user} = metadata, {from, to}, num_pages, api, options) do
+  defp write_to_archive(%{identifier: user} = metadata, {from, to}, num_pages, api, opts) do
     for page <- num_pages..1, num_pages > 0 do
-      :timer.sleep(Keyword.fetch!(options, :interval))
-      per_page = Keyword.fetch!(options, :per_page)
+      :timer.sleep(Keyword.fetch!(opts, :interval))
+      per_page = Keyword.fetch!(opts, :per_page)
 
       with {:ok, scrobbles} <- client_impl().scrobbles(user, {page - 1, per_page, from, to}, api),
            :ok <- write(metadata, scrobbles, filepath: page_path(from, page, per_page)) do
-        Logger.info("✓ page #{page} written to #{user_dir(user)}/#{page_path(from, page, per_page)}.gz")
+        Logger.info("✓ page #{page} written to #{user_dir(user, opts)}/#{page_path(from, page, per_page)}.gz")
         :ok
       else
         {:error, reason} ->
@@ -187,10 +190,6 @@ defmodule LastfmArchive.Archive.FileArchive do
           {:error, %{user: user, page: page - 1, from: from, to: to, per_page: per_page}}
       end
     end
-  end
-
-  defp today?({from, _to}) do
-    DateTime.from_unix!(from) |> DateTime.to_date() |> Kernel.==(Date.utc_today())
   end
 
   defp update_metadata(%{identifier: user} = archive, options, api) do

--- a/lib/lastfm_archive/archive/transformers/transformer.ex
+++ b/lib/lastfm_archive/archive/transformers/transformer.ex
@@ -9,7 +9,7 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
   alias Explorer.DataFrame
   alias LastfmArchive.Behaviour.Archive
 
-  import LastfmArchive.Utils, only: [maybe_create_dir: 2, check_filepath: 3, write: 2]
+  import LastfmArchive.Utils, only: [maybe_create_dir: 2, check_filepath: 2, write: 2, user_dir: 2]
   import LastfmArchive.Utils.DateTime, only: [month_range: 2, year_range: 1]
 
   require Explorer.DataFrame
@@ -75,7 +75,7 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
   defp maybe_create_archive_dir(user, opts) do
     opts
     |> validate_opts()
-    |> then(fn opts -> maybe_create_dir(user, dir: derived_archive_dir(opts)) end)
+    |> then(fn opts -> maybe_create_dir(user_dir(user, opts), sub_dir: derived_archive_dir(opts)) end)
   end
 
   def data_frame_source(metadata, year) do
@@ -96,11 +96,10 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
     Logger.info("\nWriting data from #{year}")
     opts = opts |> validate_opts()
     format = Keyword.fetch!(opts, :format)
-    filepath = "#{derived_archive_dir(opts)}/#{year}.#{format}"
-
+    filepath = Path.join([user_dir(user, opts), "#{derived_archive_dir(opts)}/#{year}.#{format}"])
     df = df |> DataFrame.filter(year == ^year)
 
-    case check_filepath(user, format, filepath) do
+    case check_filepath(format, filepath) do
       {:ok, filepath} ->
         write(df, write_fun(filepath, format))
 

--- a/lib/lastfm_archive/archive/transformers/transformer.ex
+++ b/lib/lastfm_archive/archive/transformers/transformer.ex
@@ -9,7 +9,8 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
   alias Explorer.DataFrame
   alias LastfmArchive.Behaviour.Archive
 
-  import LastfmArchive.Utils, only: [create_dir: 2, check_filepath: 3, month_range: 2, year_range: 1, write: 2]
+  import LastfmArchive.Utils, only: [maybe_create_dir: 2, check_filepath: 3, write: 2]
+  import LastfmArchive.Utils.DateTime, only: [month_range: 2, year_range: 1]
 
   require Explorer.DataFrame
   require Logger
@@ -20,7 +21,7 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
     quote do
       @behaviour LastfmArchive.Behaviour.Transformer
       import LastfmArchive.Archive.Transformers.Transformer
-      import LastfmArchive.Utils, only: [year_range: 1]
+      import LastfmArchive.Utils.DateTime, only: [year_range: 1]
 
       @impl true
       def source(metadata, opts) do
@@ -50,7 +51,7 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
   end
 
   def apply(transformer, metadata, opts) do
-    create_archive_dir(metadata.creator, opts)
+    maybe_create_archive_dir(metadata.creator, opts)
     run_pipeline(transformer, metadata, opts, Keyword.get(opts, :year, year_range(metadata.temporal) |> Enum.to_list()))
     {:ok, %{metadata | modified: DateTime.utc_now()}}
   end
@@ -71,16 +72,16 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
     transformer.source(metadata, opts) |> transformer.transform(opts) |> transformer.sink(metadata, opts)
   end
 
-  defp create_archive_dir(user, opts) do
+  defp maybe_create_archive_dir(user, opts) do
     opts
     |> validate_opts()
-    |> then(fn opts -> create_dir(user, dir: derived_archive_dir(opts)) end)
+    |> then(fn opts -> maybe_create_dir(user, dir: derived_archive_dir(opts)) end)
   end
 
   def data_frame_source(metadata, year) do
     Logger.info("\nSourcing scrobbles from #{year} into a lazy data frame.")
 
-    for month <- month_range(year, metadata) do
+    for month <- month_range(year, metadata.temporal) do
       Archive.impl().read(metadata, month: month)
     end
     |> Enum.flat_map(fn

--- a/lib/lastfm_archive/behaviour/cache.ex
+++ b/lib/lastfm_archive/behaviour/cache.ex
@@ -1,0 +1,21 @@
+defmodule LastfmArchive.Behaviour.Cache do
+  @moduledoc false
+
+  @type user :: binary()
+  @type year :: integer()
+
+  @type start_of_day_time :: integer()
+  @type end_of_day_time :: integer()
+  @type day :: {start_of_day_time, end_of_day_time}
+
+  @type playcount :: integer()
+  @type download_statuses :: list(:ok | {:error, term()})
+  @type cache_value :: {playcount(), download_statuses()}
+
+  @type options :: keyword()
+
+  @callback get({user, year}, GenServer.server()) :: map()
+  @callback load(user, GenServer.server(), keyword) :: map()
+  @callback put({user, year}, day, cache_value, options, GenServer.server()) :: :ok
+  @callback serialise(user, GenServer.server(), keyword) :: term
+end

--- a/lib/lastfm_archive/cache.ex
+++ b/lib/lastfm_archive/cache.ex
@@ -7,8 +7,10 @@ defmodule LastfmArchive.Cache do
   alias LastfmArchive.Utils
   require Logger
 
-  @cache_file_prefix ".cache_"
-  @cache_file_wildcard @cache_file_prefix <> "????"
+  import LastfmArchive.Utils.DateTime, only: [date: 1]
+
+  @cache_dir ".cache"
+  @cache_file_regex "????"
   @ticks_before_serialise 10
 
   @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
@@ -21,21 +23,15 @@ defmodule LastfmArchive.Cache do
 
   @callback get({user, year}, GenServer.server()) :: map()
   @callback load(user, GenServer.server(), keyword) :: map()
-  @callback put({user, year}, {start_of_day, end_of_day}, tuple, GenServer.server()) :: :ok
+  @callback put({user, year}, {start_of_day, end_of_day}, tuple, keyword(), GenServer.server()) :: :ok
   @callback serialise(user, GenServer.server(), keyword) :: term
+
+  def cache_dir, do: @cache_dir
+  def cache_file_regex, do: @cache_file_regex
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
   end
-
-  @spec state() :: map()
-  def state(), do: state(__MODULE__)
-
-  @spec state(GenServer.server()) :: map()
-  def state(server), do: GenServer.call(server, :state)
-
-  @spec reset(GenServer.server(), keyword) :: :ok
-  def reset(server \\ __MODULE__, options \\ []), do: GenServer.call(server, {:reset, options})
 
   @spec clear(binary, GenServer.server(), keyword) :: map()
   def clear(user, server \\ __MODULE__, options), do: GenServer.call(server, {:clear, user, options})
@@ -46,8 +42,8 @@ defmodule LastfmArchive.Cache do
 
   def get({user, year}, server), do: GenServer.call(server, {:get, {user, year}})
 
-  def put({user, year}, {from, to}, value, server \\ __MODULE__) do
-    GenServer.call(server, {:put, {user, year}, {from, to}, value})
+  def put({user, year}, {from, to}, value, options, server \\ __MODULE__) do
+    GenServer.call(server, {:put, {user, year}, {from, to}, value, options})
   end
 
   ## GenServer Callbacks
@@ -59,11 +55,6 @@ defmodule LastfmArchive.Cache do
 
   @impl true
   def handle_call(:state, _from, state), do: {:reply, state, state}
-
-  @impl true
-  def handle_call({:reset, opts}, _from, _state) do
-    {:reply, :ok, {Keyword.get(opts, :ticks, @ticks_before_serialise), %{}}}
-  end
 
   @impl true
   def handle_call({:clear, user, opts}, _from, {ticks, state}) do
@@ -79,9 +70,11 @@ defmodule LastfmArchive.Cache do
   @impl true
   def handle_call({:load, user, options}, _from, {ticks, state}) do
     new_state =
-      Path.join(Utils.user_dir(user, options), @cache_file_wildcard)
+      Path.join([Utils.user_dir(user, options), @cache_dir, @cache_file_regex])
       |> @path_io.wildcard(match_dot: true)
-      |> Enum.reduce(state, fn path, acc -> merge_cache_in_state(path, user, acc) end)
+      |> Enum.reduce(state, fn path, acc ->
+        merge_cache_in_state(path, user, acc)
+      end)
 
     {:reply, new_state, {ticks, new_state}}
   end
@@ -90,7 +83,7 @@ defmodule LastfmArchive.Cache do
   def handle_call({:serialise, user, options}, _from, {_ticks, state}) do
     results =
       for {{id, year}, value} <- state, id == user do
-        Path.join([Utils.user_dir(user, options), "#{@cache_file_prefix}#{year}"])
+        Path.join([Utils.user_dir(user, options), @cache_dir, "#{year}"])
         |> @file_io.write(value |> :erlang.term_to_binary())
       end
 
@@ -103,26 +96,22 @@ defmodule LastfmArchive.Cache do
   end
 
   @impl true
-  def handle_call({:put, {user, year}, {from, to}, value}, _from, {0, state}) do
-    path = Path.join([Utils.user_dir(user, []), "#{@cache_file_prefix}#{year}"])
+  def handle_call({:put, {user, year}, {from, to}, value, options}, _from, {0, state}) do
+    cache_file = Path.join([Utils.user_dir(user, options), @cache_dir, "#{year}"])
 
-    @file_io.write(
-      path,
-      Map.get(state, {user, year}, %{}) |> :erlang.term_to_binary()
-    )
-
-    Logger.debug("serialise archiving cache status to #{path}")
+    :ok = @file_io.write(cache_file, Map.get(state, {user, year}, %{}) |> :erlang.term_to_binary())
+    Logger.debug("serialise archiving cache status to #{cache_file}")
 
     {:reply, :ok, {@ticks_before_serialise, update_state(state, {user, year}, {from, to}, value)}}
   end
 
   @impl true
-  def handle_call({:put, {user, year}, {from, to}, value}, _from, {ticks, state}) do
+  def handle_call({:put, {user, year}, {from, to}, value, _options}, _from, {ticks, state}) do
     {:reply, :ok, {ticks - 1, update_state(state, {user, year}, {from, to}, value)}}
   end
 
   defp update_state(state, {user, year}, {from, to}, value) do
-    Logger.debug("caching archive status #{Utils.date(from)}, #{inspect(value)}")
+    Logger.debug("caching archive status #{date(from)}, #{inspect(value)}")
 
     case state[{user, year}] do
       cache when is_map(cache) ->
@@ -135,9 +124,7 @@ defmodule LastfmArchive.Cache do
 
   defp merge_cache_in_state(path, user, state) do
     cache_data = @file_io.read!(path) |> :erlang.binary_to_term()
-    year = Path.basename(path) |> cache_year()
+    year = Path.basename(path) |> String.to_integer()
     Map.merge(state, %{{user, year} => cache_data})
   end
-
-  defp cache_year(@cache_file_prefix <> year), do: year |> String.to_integer()
 end

--- a/lib/lastfm_archive/cache.ex
+++ b/lib/lastfm_archive/cache.ex
@@ -1,130 +1,24 @@
 defmodule LastfmArchive.Cache do
-  @moduledoc """
-  GenServer storing archiving state to ensure scrobbles are fetched only once.
-  """
+  @moduledoc false
+  @behaviour LastfmArchive.Behaviour.Cache
+  alias LastfmArchive.Cache.Server, as: CacheServer
 
-  use GenServer
-  alias LastfmArchive.Utils
-  require Logger
+  def clear(user, server \\ CacheServer, options), do: GenServer.call(server, {:clear, user, options})
 
-  import LastfmArchive.Utils.DateTime, only: [date: 1]
+  defdelegate cache_dir, to: CacheServer
+  defdelegate cache_file_regex, to: CacheServer
 
-  @cache_dir ".cache"
-  @cache_file_regex "????"
-  @ticks_before_serialise 10
+  @impl true
+  def get({user, year}, server \\ CacheServer), do: GenServer.call(server, {:get, {user, year}})
 
-  @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
-  @path_io Application.compile_env(:lastfm_archive, :path_io, Elixir.Path)
+  @impl true
+  def load(user, server \\ CacheServer, options \\ []), do: GenServer.call(server, {:load, user, options})
 
-  @type user :: binary()
-  @type year :: integer()
-  @type start_of_day :: integer()
-  @type end_of_day :: integer()
-
-  @callback get({user, year}, GenServer.server()) :: map()
-  @callback load(user, GenServer.server(), keyword) :: map()
-  @callback put({user, year}, {start_of_day, end_of_day}, tuple, keyword(), GenServer.server()) :: :ok
-  @callback serialise(user, GenServer.server(), keyword) :: term
-
-  def cache_dir, do: @cache_dir
-  def cache_file_regex, do: @cache_file_regex
-
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
-  end
-
-  @spec clear(binary, GenServer.server(), keyword) :: map()
-  def clear(user, server \\ __MODULE__, options), do: GenServer.call(server, {:clear, user, options})
-
-  def load(user, server \\ __MODULE__, options \\ []), do: GenServer.call(server, {:load, user, options})
-
-  def serialise(user, server \\ __MODULE__, options \\ []), do: GenServer.call(server, {:serialise, user, options})
-
-  def get({user, year}, server), do: GenServer.call(server, {:get, {user, year}})
-
-  def put({user, year}, {from, to}, value, options, server \\ __MODULE__) do
+  @impl true
+  def put({user, year}, {from, to}, value, options, server \\ CacheServer) do
     GenServer.call(server, {:put, {user, year}, {from, to}, value, options})
   end
 
-  ## GenServer Callbacks
-
   @impl true
-  def init(opts) do
-    {:ok, {Keyword.get(opts, :ticks, @ticks_before_serialise), %{}}}
-  end
-
-  @impl true
-  def handle_call(:state, _from, state), do: {:reply, state, state}
-
-  @impl true
-  def handle_call({:clear, user, opts}, _from, {ticks, state}) do
-    new_state =
-      Enum.reject(state, fn {k, _v} ->
-        elem(k, 0) == user
-      end)
-      |> Enum.into(%{})
-
-    {:reply, new_state, {Keyword.get(opts, :ticks, ticks), new_state}}
-  end
-
-  @impl true
-  def handle_call({:load, user, options}, _from, {ticks, state}) do
-    new_state =
-      Path.join([Utils.user_dir(user, options), @cache_dir, @cache_file_regex])
-      |> @path_io.wildcard(match_dot: true)
-      |> Enum.reduce(state, fn path, acc ->
-        merge_cache_in_state(path, user, acc)
-      end)
-
-    {:reply, new_state, {ticks, new_state}}
-  end
-
-  @impl true
-  def handle_call({:serialise, user, options}, _from, {_ticks, state}) do
-    results =
-      for {{id, year}, value} <- state, id == user do
-        Path.join([Utils.user_dir(user, options), @cache_dir, "#{year}"])
-        |> @file_io.write(value |> :erlang.term_to_binary())
-      end
-
-    {:reply, results, {@ticks_before_serialise, state}}
-  end
-
-  @impl true
-  def handle_call({:get, {user, year}}, _from, {ticks, state}) do
-    {:reply, Map.get(state, {user, year}, %{}), {ticks, state}}
-  end
-
-  @impl true
-  def handle_call({:put, {user, year}, {from, to}, value, options}, _from, {0, state}) do
-    cache_file = Path.join([Utils.user_dir(user, options), @cache_dir, "#{year}"])
-
-    :ok = @file_io.write(cache_file, Map.get(state, {user, year}, %{}) |> :erlang.term_to_binary())
-    Logger.debug("serialise archiving cache status to #{cache_file}")
-
-    {:reply, :ok, {@ticks_before_serialise, update_state(state, {user, year}, {from, to}, value)}}
-  end
-
-  @impl true
-  def handle_call({:put, {user, year}, {from, to}, value, _options}, _from, {ticks, state}) do
-    {:reply, :ok, {ticks - 1, update_state(state, {user, year}, {from, to}, value)}}
-  end
-
-  defp update_state(state, {user, year}, {from, to}, value) do
-    Logger.debug("caching archive status #{date(from)}, #{inspect(value)}")
-
-    case state[{user, year}] do
-      cache when is_map(cache) ->
-        update_in(state, [{user, year}, {from, to}], &(&1 = value))
-
-      nil ->
-        Map.merge(state, %{{user, year} => %{{from, to} => value}})
-    end
-  end
-
-  defp merge_cache_in_state(path, user, state) do
-    cache_data = @file_io.read!(path) |> :erlang.binary_to_term()
-    year = Path.basename(path) |> String.to_integer()
-    Map.merge(state, %{{user, year} => cache_data})
-  end
+  def serialise(user, server \\ CacheServer, options \\ []), do: GenServer.call(server, {:serialise, user, options})
 end

--- a/lib/lastfm_archive/cache/server.ex
+++ b/lib/lastfm_archive/cache/server.ex
@@ -1,0 +1,106 @@
+defmodule LastfmArchive.Cache.Server do
+  @moduledoc false
+
+  # GenServer storing archiving state to ensure scrobbles are fetched only once.
+
+  use GenServer
+
+  import LastfmArchive.Utils, only: [user_dir: 2]
+  import LastfmArchive.Utils.DateTime, only: [date: 1]
+
+  require Logger
+
+  @cache_dir ".cache"
+  @cache_file_regex "????"
+  @ticks_before_serialise 10
+
+  @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
+  @path_io Application.compile_env(:lastfm_archive, :path_io, Elixir.Path)
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(opts, :name, __MODULE__))
+  end
+
+  def cache_dir, do: @cache_dir
+  def cache_file_regex, do: @cache_file_regex
+
+  @impl true
+  def init(opts) do
+    {:ok, {Keyword.get(opts, :ticks, @ticks_before_serialise), %{}}}
+  end
+
+  @impl true
+  def handle_call(:state, _from, state), do: {:reply, state, state}
+
+  @impl true
+  def handle_call({:clear, user, opts}, _from, {ticks, state}) do
+    new_state =
+      Enum.reject(state, fn {k, _v} ->
+        elem(k, 0) == user
+      end)
+      |> Enum.into(%{})
+
+    {:reply, new_state, {Keyword.get(opts, :ticks, ticks), new_state}}
+  end
+
+  @impl true
+  def handle_call({:load, user, opts}, _from, {ticks, state}) do
+    new_state =
+      Path.join([user_dir(user, opts), @cache_dir, @cache_file_regex])
+      |> @path_io.wildcard(match_dot: true)
+      |> Enum.reduce(state, fn path, acc ->
+        merge_cache_in_state(path, user, acc)
+      end)
+
+    {:reply, new_state, {ticks, new_state}}
+  end
+
+  @impl true
+  def handle_call({:serialise, user, opts}, _from, {_ticks, state}) do
+    results =
+      for {{id, year}, value} <- state, id == user do
+        Path.join([user_dir(user, opts), @cache_dir, "#{year}"])
+        |> @file_io.write(value |> :erlang.term_to_binary())
+      end
+
+    {:reply, results, {@ticks_before_serialise, state}}
+  end
+
+  @impl true
+  def handle_call({:get, {user, year}}, _from, {ticks, state}) do
+    {:reply, Map.get(state, {user, year}, %{}), {ticks, state}}
+  end
+
+  @impl true
+  def handle_call({:put, {user, year}, {from, to}, value, opts}, _from, {0, state}) do
+    cache_file = Path.join([user_dir(user, opts), @cache_dir, "#{year}"])
+
+    :ok = @file_io.write(cache_file, Map.get(state, {user, year}, %{}) |> :erlang.term_to_binary())
+    Logger.debug("serialise archiving cache status to #{cache_file}")
+
+    {:reply, :ok, {@ticks_before_serialise, update_state(state, {user, year}, {from, to}, value)}}
+  end
+
+  @impl true
+  def handle_call({:put, {user, year}, {from, to}, value, _options}, _from, {ticks, state}) do
+    {:reply, :ok, {ticks - 1, update_state(state, {user, year}, {from, to}, value)}}
+  end
+
+  defp update_state(state, {user, year}, {from, to}, value) do
+    Logger.debug("caching archive status #{date(from)}, #{inspect(value)}")
+
+    case state[{user, year}] do
+      cache when is_map(cache) ->
+        update_in(state, [{user, year}, {from, to}], &(&1 = value))
+
+      nil ->
+        Map.merge(state, %{{user, year} => %{{from, to} => value}})
+    end
+  end
+
+  defp merge_cache_in_state(path, user, state) do
+    cache_data = @file_io.read!(path) |> :erlang.binary_to_term()
+    year = Path.basename(path) |> String.to_integer()
+    Map.merge(state, %{{user, year} => cache_data})
+  end
+end

--- a/lib/lastfm_archive/livebook.ex
+++ b/lib/lastfm_archive/livebook.ex
@@ -7,7 +7,7 @@ defmodule LastfmArchive.Livebook do
   alias LastfmArchive.LastfmClient.LastfmApi
   alias VegaLite, as: Vl
 
-  @cache LastfmArchive.Cache
+  @cache LastfmArchive.Cache.Server
   @type monthy_count :: %{count: integer(), date: String.t()}
 
   @doc """

--- a/lib/lastfm_archive/load.ex
+++ b/lib/lastfm_archive/load.ex
@@ -124,7 +124,7 @@ defmodule LastfmArchive.Load do
   """
   @spec load_solr(Hui.URL.t(), binary, binary) :: {:ok, Hui.Http.t()} | {:error, :enoent}
   def load_solr(url, user, filename) do
-    case Utils.read(user, filename) do
+    case Utils.read(Path.join(Utils.user_dir(user), filename)) do
       {:ok, resp} ->
         [header | scrobbles] = resp |> String.split("\n")
 

--- a/lib/lastfm_archive/utils/date_time.ex
+++ b/lib/lastfm_archive/utils/date_time.ex
@@ -38,5 +38,7 @@ defmodule LastfmArchive.Utils.DateTime do
     {from, to}
   end
 
+  def today?(time), do: DateTime.from_unix!(time) |> DateTime.to_date() |> Kernel.==(Date.utc_today())
+
   def year_range({from, to}), do: DateTime.from_unix!(from).year..DateTime.from_unix!(to).year
 end

--- a/lib/lastfm_archive/utils/date_time.ex
+++ b/lib/lastfm_archive/utils/date_time.ex
@@ -1,0 +1,42 @@
+defmodule LastfmArchive.Utils.DateTime do
+  @moduledoc false
+
+  def daily_time_ranges({from, to}) do
+    from = DateTime.from_unix!(from) |> DateTime.to_date()
+    to = DateTime.from_unix!(to) |> DateTime.to_date()
+    Enum.map(Date.range(from, to), &iso8601_to_unix("#{&1}T00:00:00Z", "#{&1}T23:59:59Z"))
+  end
+
+  def date_in_range?(%{temporal: {first, latest}}, {from, to}), do: from in first..latest || to in first..latest
+
+  def date(from) when is_integer(from), do: DateTime.from_unix!(from) |> DateTime.to_date()
+  def date({from, _to}) when is_integer(from), do: DateTime.from_unix!(from) |> DateTime.to_date()
+
+  def iso8601_to_unix(from, to) do
+    {:ok, from, _} = DateTime.from_iso8601(from)
+    {:ok, to, _} = DateTime.from_iso8601(to)
+
+    {DateTime.to_unix(from), DateTime.to_unix(to)}
+  end
+
+  def month_range(year, scrobbles_time_range) do
+    {from, to} = time_for_year(year, scrobbles_time_range)
+    %Date{month: first_month} = DateTime.from_unix!(from) |> DateTime.to_date()
+    %Date{month: last_month} = DateTime.from_unix!(to) |> DateTime.to_date()
+
+    for month <- 1..12, month <= last_month, month >= first_month do
+      %Date{year: year, day: 1, month: month}
+    end
+  end
+
+  def time_for_year(year, {registered_time, last_scrobble_time}) when is_integer(year) do
+    {from, to} = iso8601_to_unix("#{year}-01-01T00:00:00Z", "#{year}-12-31T23:59:59Z")
+
+    from = if from <= registered_time, do: registered_time, else: from
+    to = if to >= last_scrobble_time, do: last_scrobble_time, else: to
+
+    {from, to}
+  end
+
+  def year_range({from, to}), do: DateTime.from_unix!(from).year..DateTime.from_unix!(to).year
+end

--- a/livebook/archiving.livemd
+++ b/livebook/archiving.livemd
@@ -64,20 +64,34 @@ LastfmArchive.sync()
 
 <!-- livebook:{"branch_parent_index":2} -->
 
-## Archiving - specific year or date
+## Year option
 
-Archiving can be scoped towards tracks played of a given year. For example:
+`:year`: archiving scrobbles from a given year option. For example:
 
 ```elixir
 # change year to one containing scrobbles
 LastfmArchive.default_user() |> LastfmArchive.sync(year: 2023)
 ```
 
-Or on a specific date:
+<!-- livebook:{"branch_parent_index":2} -->
+
+## Date option
+
+`:date` archiving scrobbles from a given date
 
 ```elixir
 # change date to one containing scrobbles
-LastfmArchive.default_user() |> LastfmArchive.sync(date: ~D[2023-09-04])
+LastfmArchive.default_user() |> LastfmArchive.sync(date: ~D[2023-09-03])
+```
+
+<!-- livebook:{"branch_parent_index":2} -->
+
+## Overwrite option
+
+`:overwrite` any existing scrobbles, ignoring archiving status cache
+
+```elixir
+LastfmArchive.default_user() |> LastfmArchive.sync(date: ~D[2023-09-03], overwrite: true)
 ```
 
 <!-- livebook:{"branch_parent_index":2} -->
@@ -91,4 +105,4 @@ Run the following for a heatmap and counts, checking the archiving progress. Rer
 |> Kino.Layout.grid(columns: 2)
 ```
 
-<!-- livebook:{"offset":3079,"stamp":{"token":"QTEyOEdDTQ.1NzKk-FKz25LYAqhw06o84tWcuztAP-7A84iIeGXPE8JQphLli_ogPAPOIU.vUekR3Rjd6s1kxzx.h8f7-Hkpr9tLlTv9wGA8L_FUeqk8qgb_SBpyIDRl-t6wba6UwZb5r4mhzMSaeGHuWWo44V7Nc5_Yaoo.6h9je_8AeXOQre8TR8FpYA","version":1}} -->
+<!-- livebook:{"offset":3374,"stamp":{"token":"QTEyOEdDTQ.l19yCxas8G1C7rJjoJdhjZTywq4sDPMUv0HAAdClMQQKnZ9Dq64Pdt5nu8c.LRwDCjtbckn5i_61.4_6i45Fc02lZ1vVECPx8FNuG_Ugl6uj4EPeALcX8MSaRotLccyOc1fxgMZvkizhPsjM8vOBHsfwBCuM.ynfEbr5T6eKphZprcIMQ5w","version":1}} -->

--- a/livebook/archiving.livemd
+++ b/livebook/archiving.livemd
@@ -4,7 +4,7 @@
 
 ```elixir
 Mix.install(
-  [{:lastfm_archive, "~> 1.0"}],
+  [{:lastfm_archive, "~> 1.1"}],
   config: [
     lastfm_archive: [
       data_dir: "./lastfm_data/",
@@ -64,6 +64,24 @@ LastfmArchive.sync()
 
 <!-- livebook:{"branch_parent_index":2} -->
 
+## Archiving - specific year or date
+
+Archiving can be scoped towards tracks played of a given year. For example:
+
+```elixir
+# change year to one containing scrobbles
+LastfmArchive.default_user() |> LastfmArchive.sync(year: 2023)
+```
+
+Or on a specific date:
+
+```elixir
+# change date to one containing scrobbles
+LastfmArchive.default_user() |> LastfmArchive.sync(date: ~D[2023-09-04])
+```
+
+<!-- livebook:{"branch_parent_index":2} -->
+
 ## Status
 
 Run the following for a heatmap and counts, checking the archiving progress. Rerun the code to get the latest status.
@@ -72,3 +90,5 @@ Run the following for a heatmap and counts, checking the archiving progress. Rer
 [LFM_LB.monthly_playcounts_heatmap(), LFM_LB.yearly_playcounts_table()]
 |> Kino.Layout.grid(columns: 2)
 ```
+
+<!-- livebook:{"offset":3079,"stamp":{"token":"QTEyOEdDTQ.1NzKk-FKz25LYAqhw06o84tWcuztAP-7A84iIeGXPE8JQphLli_ogPAPOIU.vUekR3Rjd6s1kxzx.h8f7-Hkpr9tLlTv9wGA8L_FUeqk8qgb_SBpyIDRl-t6wba6UwZb5r4mhzMSaeGHuWWo44V7Nc5_Yaoo.6h9je_8AeXOQre8TR8FpYA","version":1}} -->

--- a/livebook/transforming.livemd
+++ b/livebook/transforming.livemd
@@ -4,7 +4,7 @@
 
 ```elixir
 Mix.install(
-  [{:lastfm_archive, "~> 1.0"}, {:kino_explorer, "~> 0.1.8"}],
+  [{:lastfm_archive, "~> 1.1"}, {:kino_explorer, "~> 0.1.8"}],
   config: [
     lastfm_archive: [
       data_dir: "./lastfm_data/",
@@ -120,4 +120,4 @@ To compute all unique tracks by artists:
 df_all |> Explorer.DataFrame.collect() |> Explorer.DataFrame.frequencies([:track, :artist])
 ```
 
-<!-- livebook:{"offset":5015,"stamp":{"token":"QTEyOEdDTQ.Xg3uhJpDHYNagAxTwYAWzllRZsCyU5Sy0Axb8-RY8jrFpBaOFJ-tmoFZU38.F_OMU68HszkcLuWW._uvrOtUxizcGhI6R4Gv-v3ypUgrBM7OXWXGbsAmPh2v_cZrcCUFMflQsy3UXZvkL3YfEXJ-dyYDrhiQ.ReuVgeEMpS6DaWZYWmeVGg","version":1}} -->
+<!-- livebook:{"offset":5117,"stamp":{"token":"QTEyOEdDTQ.JLJYfOTg9hxBYen7I450mxplgreCjyszxYxtYPHn71rLMtWaqOqPbTn2i_Y.-7J7TfiYakuAAEXT.nxPtKzUhoklNH-42cwW68KIIwi_xMro-aO7mckj_9dmTFh0qBJoSVPLuqA.ys8KH58zKBN7jiFyvgjVrw","version":1}} -->

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule LastfmArchive.MixProject do
   def project do
     [
       app: :lastfm_archive,
-      version: "1.0.0",
+      version: "1.1.0",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
@@ -23,7 +23,7 @@ defmodule LastfmArchive.MixProject do
       source_url: "https://github.com/boonious/lastfm_archive",
       homepage_url: "https://github.com/boonious/lastfm_archive",
       docs: [
-        main: "LastfmArchive",
+        main: "readme",
         extras: [
           "README.md",
           "CHANGELOG.md",

--- a/test/lastfm_archive/archive/file_archive_test.exs
+++ b/test/lastfm_archive/archive/file_archive_test.exs
@@ -5,13 +5,15 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
   import Fixtures.{Archive, Lastfm}
   import Hammox
 
+  import LastfmArchive.Utils, only: [user_dir: 1]
+  import LastfmArchive.Utils.DateTime, only: [daily_time_ranges: 1]
+
   alias Explorer.DataFrame
 
   alias LastfmArchive.Archive.FileArchive
   alias LastfmArchive.Archive.Metadata
   alias LastfmArchive.Behaviour.Archive
   alias LastfmArchive.Behaviour.LastfmClient
-  alias LastfmArchive.Utils
 
   @column_count (%LastfmArchive.Archive.Scrobble{} |> Map.keys() |> length()) - 1
 
@@ -59,36 +61,77 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
       capture_log(fn -> assert {:ok, %Metadata{}} = FileArchive.archive(metadata, []) end)
     end
 
-    test "writes scrobbles to files", %{
+    test "scrobbles to files", %{
       metadata: metadata,
       scrobbles_json: scrobbles_json,
       user: user
     } do
+      cache_dir = Path.join(user_dir(user), LastfmArchive.Cache.cache_dir())
+
+      # ensure cache hiddern dir is available
+      LastfmArchive.FileIOMock
+      |> expect(:exists?, fn ^cache_dir -> false end)
+      |> expect(:mkdir_p, fn ^cache_dir -> :ok end)
+
       # write 3 files for 3-day test archive duration
       LastfmArchive.FileIOMock
       |> expect(:exists?, 3, fn _page_dir -> false end)
       |> expect(:mkdir_p, 3, fn _page_dir -> :ok end)
-      |> expect(:write, 3, fn full_path, ^scrobbles_json, [:compressed] ->
-        assert full_path =~ "./lastfm_data/test/#{user}/2021/04"
-        assert full_path =~ "/200_001.gz"
+      |> expect(:write, 3, fn path, ^scrobbles_json, [:compressed] ->
+        assert path =~ "./lastfm_data/test/#{user}/2021/04"
+        assert path =~ "/200_001.gz"
         :ok
       end)
 
       capture_log(fn -> FileArchive.archive(metadata, []) end)
     end
 
-    test "caches archiving ok status", %{metadata: metadata, user: user} do
+    test "scrobbles of a given year option", %{
+      metadata: metadata,
+      scrobbles_json: scrobbles_json
+    } do
+      LastfmArchive.FileIOMock
+      |> expect(:write, 3, fn path, ^scrobbles_json, [:compressed] ->
+        assert path =~ "/2021/"
+        :ok
+      end)
+
+      capture_log(fn -> FileArchive.archive(metadata, year: 2021) end)
+    end
+
+    test "scrobbles of a given date option", %{
+      metadata: metadata,
+      scrobbles_json: scrobbles_json
+    } do
+      LastfmArchive.FileIOMock
+      |> expect(:write, fn path, ^scrobbles_json, [:compressed] ->
+        assert path =~ "/2021/04/01"
+        :ok
+      end)
+
+      capture_log(fn -> FileArchive.archive(metadata, date: ~D[2021-04-01]) end)
+    end
+
+    test "raises when year option out of range", %{metadata: metadata} do
+      assert_raise(RuntimeError, fn -> FileArchive.archive(metadata, year: 2023) end)
+    end
+
+    test "raises when date option out of range", %{metadata: metadata} do
+      assert_raise(RuntimeError, fn -> FileArchive.archive(metadata, date: ~D[2023-05-01]) end)
+    end
+
+    test "caches ok status", %{metadata: metadata, user: user} do
       LastfmArchive.CacheMock
-      |> expect(:put, 3, fn {^user, 2021}, _time, {_playcount, [:ok]}, _cache -> :ok end)
+      |> expect(:put, 3, fn {^user, 2021}, _time, {_playcount, [:ok]}, _opts, _cache -> :ok end)
 
       capture_log(fn -> FileArchive.archive(metadata, []) end)
     end
 
-    test "caches status on scrobbles API call errors", %{metadata: metadata, user: user} do
+    test "caches status on Lastfm API call errors", %{metadata: metadata, user: user} do
       LastfmClient.impl() |> expect(:scrobbles, 3, fn _user, _client_args, _client -> {:error, "error"} end)
 
       LastfmArchive.CacheMock
-      |> expect(:put, 3, fn {^user, 2021}, _time, {_playcount, [error: _data]}, _cache -> :ok end)
+      |> expect(:put, 3, fn {^user, 2021}, _time, {_playcount, [error: _data]}, _opts, _cache -> :ok end)
 
       assert capture_log(fn -> FileArchive.archive(metadata, []) end) =~ "Lastfm API error"
     end
@@ -113,7 +156,7 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
       |> expect(:scrobbles, fn ^user, _client_args, _client -> {:ok, %{}} end)
 
       LastfmArchive.CacheMock
-      |> expect(:put, 0, fn {_user, _year}, {_from, _to}, {_total_scrobbles, _status}, _cache -> :ok end)
+      |> expect(:put, 0, fn {_user, _year}, {_from, _to}, {_total_scrobbles, _status}, _opts, _cache -> :ok end)
 
       assert capture_log(fn -> FileArchive.archive(metadata, []) end) =~ Date.utc_today() |> to_string
     end
@@ -144,7 +187,7 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
       |> stub(:scrobbles, fn ^user, _client_args, _client -> {:ok, scrobbles} end)
 
       LastfmArchive.CacheMock
-      |> expect(:put, 0, fn {^user, 2021}, _time, {_playcount, _status}, _cache -> :ok end)
+      |> expect(:put, 0, fn {^user, 2021}, _time, {_playcount, _status}, _opts, _cache -> :ok end)
 
       assert capture_log(fn -> FileArchive.archive(metadata, []) end) =~ "Lastfm API error"
     end
@@ -181,7 +224,7 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
 
       cache_ok_status =
         metadata.temporal
-        |> Utils.build_time_range()
+        |> daily_time_ranges()
         |> Enum.into(%{}, fn time_range -> {time_range, {daily_playcount, [:ok]}} end)
 
       LastfmArchive.CacheMock |> expect(:get, fn {^user, 2021}, _cache -> cache_ok_status end)
@@ -198,7 +241,7 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
       date = Date.utc_today()
       day = date |> to_string() |> String.replace("-", "/")
       archive_file = "200_001.gz"
-      user_dir = Utils.user_dir(metadata.creator) <> "/#{day}"
+      user_dir = user_dir(metadata.creator) <> "/#{day}"
       file_path = user_dir <> "/#{archive_file}"
 
       LastfmArchive.FileIOMock
@@ -223,7 +266,7 @@ defmodule LastfmArchive.Archive.FileArchiveTest do
     test "returns data frame for a month's scrobbles", %{metadata: metadata} do
       date = ~D[2023-06-01]
       user = "a_lastfm_user"
-      user_dir = Utils.user_dir(user)
+      user_dir = user_dir(user)
       wildcard_path = "#{user_dir}/2023/06/**/*.gz"
 
       files = [

--- a/test/lastfm_archive/behaviour/archive_test.exs
+++ b/test/lastfm_archive/behaviour/archive_test.exs
@@ -50,7 +50,7 @@ defmodule LastfmArchive.Behaviour.ArchiveTest do
              } = archive.update_metadata(metadata, data_dir: "test_data_dir")
     end
 
-    test "reset an existing archive via 'reset' option", %{archive: archive} do
+    test "reset an existing archive metadata via 'reset' option", %{archive: archive} do
       earlier_created_datetime = DateTime.add(DateTime.utc_now(), -3600, :second)
       metadata = file_archive_metadata("a_user", earlier_created_datetime)
 

--- a/test/lastfm_archive/cache_test.exs
+++ b/test/lastfm_archive/cache_test.exs
@@ -3,6 +3,7 @@ defmodule LastfmArchive.CacheTest do
 
   import Hammox
   alias LastfmArchive.Cache
+  alias LastfmArchive.Utils
 
   @cache :test_cache
   @ticks_before_serialise 2
@@ -14,28 +15,11 @@ defmodule LastfmArchive.CacheTest do
     {:ok, _pid} =
       start_supervised(%{id: @cache, start: {Cache, :start_link, [[name: @cache, ticks: @ticks_before_serialise]]}})
 
-    %{cache: %{{"a_user", 2006} => %{{1_138_752_000, 1_138_838_399} => {33, [:ok]}}}}
+    %{user: "a_user", cache: %{{"a_user", 2006} => %{{1_138_752_000, 1_138_838_399} => {33, [:ok]}}}}
   end
 
   test "init/1 with ticks count and empty state" do
-    assert {@ticks_before_serialise, %{}} == Cache.state(@cache)
-  end
-
-  test "state/0 returns current state of app cache" do
-    assert {10, %{}} == Cache.state()
-  end
-
-  test "state/1 returns current state", %{cache: cache} do
-    :sys.replace_state(@cache, fn _state -> {60, cache} end)
-    assert {60, ^cache} = Cache.state(@cache)
-  end
-
-  test "reset/2 state", %{cache: cache} do
-    :sys.replace_state(@cache, fn _state -> {60, cache} end)
-
-    Cache.reset(@cache, ticks: 13)
-    refute {60, cache} == Cache.state(@cache)
-    assert {13, %{}} == Cache.state(@cache)
+    assert {@ticks_before_serialise, %{}} == :sys.get_state(@cache)
   end
 
   test "clear/3 state", %{cache: cache} do
@@ -43,27 +27,29 @@ defmodule LastfmArchive.CacheTest do
     [{user, _2006}] = cache |> Map.keys()
 
     Cache.clear(user, @cache, ticks: 13)
-    refute {60, cache} == Cache.state(@cache)
-    assert {13, %{}} = Cache.state(@cache)
+    refute {60, cache} == :sys.get_state(@cache)
+    assert {13, %{}} = :sys.get_state(@cache)
   end
 
-  test "load/3 cache from file for a user", %{cache: cache} do
-    LastfmArchive.PathIOMock |> expect(:wildcard, fn _, _ -> [".cache_2006"] end)
+  test "load/3 cache from file for a user", %{user: user, cache: cache} do
+    cache_file = "#{Utils.user_dir(user)}/#{Cache.cache_dir()}/2006"
+    cache_file_regex = Path.join([Utils.user_dir(user), Cache.cache_dir(), Cache.cache_file_regex()])
+
+    LastfmArchive.PathIOMock
+    |> expect(:wildcard, fn ^cache_file_regex, [match_dot: true] -> [cache_file] end)
 
     LastfmArchive.FileIOMock
-    |> expect(:read!, fn _ -> cache[{"a_user", 2006}] |> :erlang.term_to_binary() end)
+    |> expect(:read!, fn ^cache_file -> cache[{"a_user", 2006}] |> :erlang.term_to_binary() end)
 
     assert ^cache = Cache.load("a_user", @cache)
   end
 
   test "serialise/3 cache to a file", %{cache: cache} do
     :sys.replace_state(@cache, fn _state -> {60, cache} end)
+    cache_file = Path.join(Utils.user_dir("a_user"), "#{Cache.cache_dir()}/2006")
     file_binary = cache[{"a_user", 2006}] |> :erlang.term_to_binary()
-    to_path = Path.join([Application.get_env(:lastfm_archive, :data_dir), "a_user", ".cache_2006"])
 
-    LastfmArchive.FileIOMock
-    |> expect(:write, fn ^to_path, ^file_binary -> :ok end)
-
+    LastfmArchive.FileIOMock |> expect(:write, fn ^cache_file, ^file_binary -> :ok end)
     Cache.serialise("a_user", @cache)
   end
 
@@ -74,19 +60,21 @@ defmodule LastfmArchive.CacheTest do
     assert %{} == Cache.get({"not_exiting_user", 2021}, @cache)
   end
 
-  test "put/4 cache value for a user year" do
+  test "put/5 cache value for a user year" do
+    options = []
     assert %{} == Cache.get({"a_user", 2006}, @cache)
 
-    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, @cache)
+    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, options, @cache)
     assert %{{1_138_752_000, 1_138_838_399} => {12_345, [:ok]}} == Cache.get({"a_user", 2006}, @cache)
   end
 
-  test "successive put/4 causing auto-serialisation of cache to file" do
+  test "successive put/5 causing auto-serialisation of cache to file" do
+    options = []
     LastfmArchive.FileIOMock |> expect(:write, fn _to_path, _file_binary -> :ok end)
 
     # put counts > 2 `ticks` configured for the test cache
-    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, @cache)
-    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, @cache)
-    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, @cache)
+    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, options, @cache)
+    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, options, @cache)
+    Cache.put({"a_user", 2006}, {1_138_752_000, 1_138_838_399}, {12_345, [:ok]}, options, @cache)
   end
 end

--- a/test/lastfm_archive/cache_test.exs
+++ b/test/lastfm_archive/cache_test.exs
@@ -3,6 +3,7 @@ defmodule LastfmArchive.CacheTest do
 
   import Hammox
   alias LastfmArchive.Cache
+  alias LastfmArchive.Cache.Server, as: CacheServer
   alias LastfmArchive.Utils
 
   @cache :test_cache
@@ -13,7 +14,10 @@ defmodule LastfmArchive.CacheTest do
 
   setup do
     {:ok, _pid} =
-      start_supervised(%{id: @cache, start: {Cache, :start_link, [[name: @cache, ticks: @ticks_before_serialise]]}})
+      start_supervised(%{
+        id: @cache,
+        start: {CacheServer, :start_link, [[name: @cache, ticks: @ticks_before_serialise]]}
+      })
 
     %{user: "a_user", cache: %{{"a_user", 2006} => %{{1_138_752_000, 1_138_838_399} => {33, [:ok]}}}}
   end

--- a/test/lastfm_archive/livebook_test.exs
+++ b/test/lastfm_archive/livebook_test.exs
@@ -6,6 +6,7 @@ defmodule LastfmArchive.LivebookTest do
   alias LastfmArchive.Behaviour.LastfmClient
   alias LastfmArchive.Cache
   alias LastfmArchive.Livebook, as: LFM_LB
+  alias LastfmArchive.Utils
 
   @cache :livebooktest_cache
 
@@ -16,8 +17,9 @@ defmodule LastfmArchive.LivebookTest do
     {:ok, _pid} = start_supervised(%{id: @cache, start: {Cache, :start_link, [[name: @cache]]}})
     cache = %{{"a_user", 2006} => %{{1_138_752_000, 1_138_838_399} => {33, [:ok]}}}
 
+    cache_file = "#{Utils.user_dir("a_user")}/#{Cache.cache_dir()}/2006"
     stub_with(LastfmClient.impl(), LastfmArchive.LastfmClientStub)
-    LastfmArchive.PathIOMock |> stub(:wildcard, fn _, _ -> [".cache_2006"] end)
+    LastfmArchive.PathIOMock |> stub(:wildcard, fn _, _ -> [cache_file] end)
     LastfmArchive.FileIOMock |> stub(:read!, fn _ -> cache[{"a_user", 2006}] |> :erlang.term_to_binary() end)
 
     :ok

--- a/test/lastfm_archive/livebook_test.exs
+++ b/test/lastfm_archive/livebook_test.exs
@@ -5,6 +5,7 @@ defmodule LastfmArchive.LivebookTest do
 
   alias LastfmArchive.Behaviour.LastfmClient
   alias LastfmArchive.Cache
+  alias LastfmArchive.Cache.Server, as: CacheServer
   alias LastfmArchive.Livebook, as: LFM_LB
   alias LastfmArchive.Utils
 
@@ -14,7 +15,7 @@ defmodule LastfmArchive.LivebookTest do
   setup :verify_on_exit!
 
   setup do
-    {:ok, _pid} = start_supervised(%{id: @cache, start: {Cache, :start_link, [[name: @cache]]}})
+    {:ok, _pid} = start_supervised(%{id: @cache, start: {CacheServer, :start_link, [[name: @cache]]}})
     cache = %{{"a_user", 2006} => %{{1_138_752_000, 1_138_838_399} => {33, [:ok]}}}
 
     cache_file = "#{Utils.user_dir("a_user")}/#{Cache.cache_dir()}/2006"

--- a/test/lastfm_archive/utils/date_time_test.exs
+++ b/test/lastfm_archive/utils/date_time_test.exs
@@ -1,0 +1,34 @@
+defmodule LastfmArchive.Utils.DateTimeTest do
+  use ExUnit.Case, async: true
+  import LastfmArchive.Utils.DateTime, only: [daily_time_ranges: 1, time_for_year: 2, year_range: 1]
+
+  test "daily_time_ranges/1" do
+    {:ok, from, 0} = DateTime.from_iso8601("2010-12-23T18:50:07Z")
+    {:ok, to, 0} = DateTime.from_iso8601("2011-01-13T11:06:25Z")
+
+    time_ranges = daily_time_ranges({DateTime.to_unix(from), DateTime.to_unix(to)})
+
+    for day <- Date.range(Date.from_erl!({2010, 12, 23}), Date.from_erl!({2011, 1, 13})) do
+      {:ok, from, _} = DateTime.from_iso8601("#{day}T00:00:00Z")
+      {:ok, to, _} = DateTime.from_iso8601("#{day}T23:59:59Z")
+
+      assert {DateTime.to_unix(from), DateTime.to_unix(to)} in time_ranges
+    end
+  end
+
+  test "time_for_year/2" do
+    {:ok, registered_date, 0} = DateTime.from_iso8601("2018-01-13T11:06:25Z")
+    {:ok, last_scrobble_date, 0} = DateTime.from_iso8601("2021-05-04T12:55:25Z")
+
+    assert {1_577_836_800, 1_609_459_199} ==
+             time_for_year(2020, {DateTime.to_unix(registered_date), DateTime.to_unix(last_scrobble_date)})
+  end
+
+  test "year_range/1 from first and latest scrobble times" do
+    {:ok, from, 0} = DateTime.from_iso8601("2008-12-23T18:50:07Z")
+    {:ok, to, 0} = DateTime.from_iso8601("2021-01-13T11:06:25Z")
+
+    year_range = year_range({DateTime.to_unix(from), DateTime.to_unix(to)})
+    for year <- 2008..2021, do: assert(year in year_range)
+  end
+end

--- a/test/lastfm_archive/utils_test.exs
+++ b/test/lastfm_archive/utils_test.exs
@@ -8,44 +8,6 @@ defmodule LastfmArchive.UtilsTest do
   alias LastfmArchive.Utils
   alias LastfmArchive.Archive.Metadata
 
-  describe "build_time_range" do
-    test "provides daily time range" do
-      {:ok, from, 0} = DateTime.from_iso8601("2010-12-23T18:50:07Z")
-      {:ok, to, 0} = DateTime.from_iso8601("2011-01-13T11:06:25Z")
-
-      time_ranges = Utils.build_time_range({DateTime.to_unix(from), DateTime.to_unix(to)})
-
-      for day <- Date.range(Date.from_erl!({2010, 12, 23}), Date.from_erl!({2011, 1, 13})) do
-        {:ok, from, _} = DateTime.from_iso8601("#{day}T00:00:00Z")
-        {:ok, to, _} = DateTime.from_iso8601("#{day}T23:59:59Z")
-
-        assert {DateTime.to_unix(from), DateTime.to_unix(to)} in time_ranges
-      end
-    end
-
-    test "provides year time range" do
-      {:ok, registered_date, 0} = DateTime.from_iso8601("2018-01-13T11:06:25Z")
-      {:ok, last_scrobble_date, 0} = DateTime.from_iso8601("2021-05-04T12:55:25Z")
-
-      assert {1_577_836_800, 1_609_459_199} ==
-               Utils.build_time_range(2020, %Metadata{
-                 creator: "a_lastfm_user",
-                 temporal: {DateTime.to_unix(registered_date), DateTime.to_unix(last_scrobble_date)}
-               })
-    end
-  end
-
-  test "year_range/1 from first and latest scrobble times" do
-    {:ok, from, 0} = DateTime.from_iso8601("2008-12-23T18:50:07Z")
-    {:ok, to, 0} = DateTime.from_iso8601("2021-01-13T11:06:25Z")
-
-    year_range = Utils.year_range({DateTime.to_unix(from), DateTime.to_unix(to)})
-
-    for year <- 2008..2021 do
-      assert year in year_range
-    end
-  end
-
   test "metadata_filepath/2" do
     opts = []
     filepath = ".metadata/scrobbles/json_archive"

--- a/test/lastfm_archive/utils_test.exs
+++ b/test/lastfm_archive/utils_test.exs
@@ -1,6 +1,7 @@
 defmodule LastfmArchive.UtilsTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
   import Hammox
   import Fixtures.Archive
   import Fixtures.Lastfm
@@ -22,8 +23,7 @@ defmodule LastfmArchive.UtilsTest do
     assert Utils.metadata_filepath("user", opts) == "#{Utils.user_dir("user", opts)}/#{filepath}"
   end
 
-  test "read/2 file from the archive for a given user and file location" do
-    test_user = "load_test_user"
+  test "read/1 file from the archive for a given user and file location" do
     csv_file = Path.join(Utils.user_dir("load_test_user"), "csv/2018.csv.gz")
     non_existing_file = Path.join(Utils.user_dir("load_test_user"), "non_existing_file.csv.gz")
 
@@ -31,8 +31,8 @@ defmodule LastfmArchive.UtilsTest do
     |> expect(:read, fn ^non_existing_file -> {:error, :enoent} end)
     |> expect(:read, fn ^csv_file -> {:ok, csv_gzip_data()} end)
 
-    assert {:error, :enoent} = Utils.read(test_user, "non_existing_file.csv.gz")
-    assert {:ok, resp} = Utils.read(test_user, "csv/2018.csv.gz")
+    capture_log(fn -> assert {:error, :enoent} = Utils.read(non_existing_file) end)
+    assert {:ok, resp} = Utils.read(csv_file)
 
     [_header | scrobbles] = resp |> String.split("\n")
     assert length(scrobbles) > 0

--- a/test/support/cache_stub.ex
+++ b/test/support/cache_stub.ex
@@ -1,7 +1,7 @@
 defmodule LastfmArchive.CacheStub do
   @moduledoc false
 
-  @behaviour LastfmArchive.Cache
+  @behaviour LastfmArchive.Behaviour.Cache
 
   def load(_user, _cache, _options), do: %{}
   def put({_user, _year}, {_from, _to}, _value, _options, _cache), do: :ok

--- a/test/support/cache_stub.ex
+++ b/test/support/cache_stub.ex
@@ -4,7 +4,7 @@ defmodule LastfmArchive.CacheStub do
   @behaviour LastfmArchive.Cache
 
   def load(_user, _cache, _options), do: %{}
-  def put({_user, _year}, {_from, _to}, _value, _cache), do: :ok
+  def put({_user, _year}, {_from, _to}, _value, _options, _cache), do: :ok
   def serialise(_user, _cache, _options), do: :ok
   def get({_user, _year}, _cache), do: %{}
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -3,7 +3,7 @@ alias LastfmArchive.Behaviour
 Hammox.defmock(LastfmArchive.Archive.FileArchiveMock, for: Behaviour.Archive)
 Hammox.defmock(LastfmArchive.Archive.DerivedArchiveMock, for: Behaviour.Archive)
 
-Hammox.defmock(LastfmArchive.CacheMock, for: LastfmArchive.Cache)
+Hammox.defmock(LastfmArchive.CacheMock, for: Behaviour.Cache)
 Hammox.defmock(LastfmArchive.FileIOMock, for: Behaviour.FileIO)
 Hammox.defmock(LastfmArchive.LastfmClientMock, for: Behaviour.LastfmClient)
 Hammox.defmock(LastfmArchive.PathIOMock, for: Behaviour.PathIO)


### PR DESCRIPTION
This PR provides the following options for `LastfmArchive.sync/2`
- `year`, `date`: archive scrobbles from this particular year, date only instead of everything
- `overwrite`: re-fetch scrobbles from Lastfm, overwrites any existing downloads

It also provides the following refactoring:
- use `.cache` hidden directory to host all archiving progress cache files
- extract date time concerns from `Utils` into a separate module
- split `LastfmArchive.Cache` into behaviour, client, server modules

Bumps to v.1.1.