### PR TITLE
feat: convenient function to sync and transform latest scrobbles

### DIFF
--- a/lib/lastfm_archive/archive/transformers/transformer.ex
+++ b/lib/lastfm_archive/archive/transformers/transformer.ex
@@ -57,8 +57,12 @@ defmodule LastfmArchive.Archive.Transformers.Transformer do
     Path.join(user_dir(metadata.creator, opts), derived_archive_dir(opts |> validate_opts()))
     |> maybe_create_dir()
 
-    run_pipeline(transformer, metadata, opts, Keyword.get(opts, :year, year_range(metadata.temporal) |> Enum.to_list()))
+    run_pipeline(transformer, metadata, opts, Keyword.get(opts, :year))
     {:ok, %{metadata | modified: DateTime.utc_now()}}
+  end
+
+  defp run_pipeline(transformer, metadata, opts, year) when is_nil(year) do
+    run_pipeline(transformer, metadata, opts, year_range(metadata.temporal) |> Enum.to_list())
   end
 
   defp run_pipeline(transformer, metadata, opts, year) when is_integer(year) do

--- a/lib/lastfm_archive/archive/transformers/transformer_configs.ex
+++ b/lib/lastfm_archive/archive/transformers/transformer_configs.ex
@@ -27,7 +27,7 @@ defmodule LastfmArchive.Archive.Transformers.TransformerConfigs do
     end
   end
 
-  def default_opts, do: [format: :ipc_stream, facet: :scrobbles, overwrite: false]
+  def default_opts, do: [facet: :scrobbles, format: :ipc_stream, overwrite: false, year: nil]
   def facets, do: facet_transformers_configs() |> Map.keys()
   def formats, do: format_configs() |> Map.keys()
 

--- a/lib/lastfm_archive/utils/archive.ex
+++ b/lib/lastfm_archive/utils/archive.ex
@@ -5,6 +5,7 @@ defmodule LastfmArchive.Utils.Archive do
 
   @metadata_dir ".metadata"
   @data_dir Application.compile_env(:lastfm_archive, :data_dir, "./lastfm_data/")
+  @file_io Application.compile_env(:lastfm_archive, :file_io, Elixir.File)
 
   def metadata_filepath(user, opts \\ []) do
     Path.join([
@@ -12,6 +13,13 @@ defmodule LastfmArchive.Utils.Archive do
       user,
       "#{@metadata_dir}/#{Keyword.get(opts, :facet, "scrobbles")}/#{Keyword.get(opts, :format, "json")}_archive"
     ])
+  end
+
+  def check_existing_archive(user, options) do
+    case metadata_filepath(user, options) |> @file_io.exists?() do
+      true -> {:ok, metadata_filepath(user, options)}
+      false -> {:error, :archive_not_found}
+    end
   end
 
   def num_pages(playcount, per_page), do: (playcount / per_page) |> :math.ceil() |> round


### PR DESCRIPTION
This PR implements `update_latest/2` to enable convenient syncing of the latest scrobbles and transforming them into existing faceted archives.